### PR TITLE
[fix] Swagger PetStore 기본 페이지 노출 버그 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,4 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+    url: /api/api-docs


### PR DESCRIPTION
## 📌 작업 개요
- 배포 서버 Swagger 관련 버그 2건 수정

## ✨ 주요 변경 사항
- `application.yml`의 `springdoc` 설정을 루트 레벨로 이동 (PetStore 기본 페이지 노출 수정)
- `SwaggerConfig`의 서버 URL 환경변수 미해석 문제 수정
  - `@OpenAPIDefinition` 어노테이션의 `${API_SERVER_URL}` 플레이스홀더가 resolve되지 않던 문제
  - `@Value` 주입 방식으로 변경, 환경변수 미설정 시 서버 목록 미등록으로 안전하게 폴백

## 💬 기타 참고 사항
- 배포 서버에서 Swagger 접속 시 PetStore 기본 페이지가 노출되던 원인
- API 요청 시 `$%7BAPI_SERVER_URL%7D/events` 로 요청되던 원인