### PR TITLE
[fix] SwaggerConfig 서버 URL 환경변수 미해석 문제 수정

### DIFF
--- a/src/main/java/com/gifo/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/gifo/backend/config/SwaggerConfig.java
@@ -1,36 +1,35 @@
 package com.gifo.backend.config;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "${API_SERVER_URL}", description = "gifo https 서버입니다."),
-                @Server(url = "http://localhost:8080", description = "gifo local 서버입니다.")
-        }
-)
+import java.util.List;
+
 @Configuration
 public class SwaggerConfig {
+
+    @Value("${API_SERVER_URL:}")
+    private String apiServerUrl;
+
     @Bean
     public OpenAPI openAPI() {
-        return new OpenAPI()
+        OpenAPI openAPI = new OpenAPI()
                 .info(new Info()
                         .title("Gifo API 문서")
                         .description("Gifo API 명세입니다.")
                         .version("v1.0.0"));
-//                .components(new Components()
-//                        .addSecuritySchemes("bearer-key", new SecurityScheme()
-//                                .type(SecurityScheme.Type.HTTP)
-//                                .scheme("bearer")
-//                                .bearerFormat("JWT"))
-//                        .addSecuritySchemes("refresh-token", new SecurityScheme()
-//                                .type(SecurityScheme.Type.APIKEY)
-//                                .in(SecurityScheme.In.HEADER)
-//                                .name("Authorization"))
-//                );
+
+        if (apiServerUrl != null && !apiServerUrl.isBlank()) {
+            openAPI.servers(List.of(
+                    new Server().url(apiServerUrl).description("gifo https 서버입니다."),
+                    new Server().url("http://localhost:8080").description("gifo local 서버입니다.")
+            ));
+        }
+
+        return openAPI;
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- `SwaggerConfig`에서 `${API_SERVER_URL}` 환경변수가 해석되지 않아 Swagger API 요청이 `$%7BAPI_SERVER_URL%7D/events`로 전송되던 버그 수정

---

## ✨ 주요 변경 사항
- `@OpenAPIDefinition` 어노테이션 제거 → `OpenAPI` 빈 내 `@Value` 주입 방식으로 변경
- `API_SERVER_URL` 환경변수 미설정 시 서버 목록을 추가하지 않아 로컬 환경에서 안전하게 폴백

---

## ✅ 작업 체크리스트
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성

---

## 📂 테스트 방법
- `API_SERVER_URL` 환경변수 설정 후 Swagger UI에서 서버 목록 정상 표시 확인
- `API_SERVER_URL` 미설정 시 오류 없이 기동 확인

---

## 📎 관련 이슈 / 문서
- 연관 PR: #11 (springdoc 설정 루트 레벨 이동)