### PR TITLE
[fix] Swagger 서버 URL 단일화 및 api-docs url 설정 제거

### DIFF
--- a/src/main/java/com/gifo/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/gifo/backend/config/SwaggerConfig.java
@@ -23,12 +23,10 @@ public class SwaggerConfig {
                         .description("Gifo API 명세입니다.")
                         .version("v1.0.0"));
 
-        if (apiServerUrl != null && !apiServerUrl.isBlank()) {
-            openAPI.servers(List.of(
-                    new Server().url(apiServerUrl).description("gifo https 서버입니다."),
-                    new Server().url("http://localhost:8080").description("gifo local 서버입니다.")
-            ));
-        }
+        String serverUrl = (apiServerUrl != null && !apiServerUrl.isBlank())
+                ? apiServerUrl
+                : "http://localhost:8080";
+        openAPI.servers(List.of(new Server().url(serverUrl)));
 
         return openAPI;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,4 +29,3 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
-    url: /api/api-docs


### PR DESCRIPTION
## 📌 작업 개요
- Swagger UI 서버 목록을 환경에 따라 1개만 표시되도록 수정
- 잘못된 api-docs URL 설정 제거

---

## ✨ 주요 변경 사항
- `SwaggerConfig`: 환경변수 `API_SERVER_URL` 설정 여부에 따라 서버 URL 1개만 등록
  - 배포 서버: `API_SERVER_URL` 값 사용
  - 로컬: `http://localhost:8080` 폴백
- `application.yml`: `swagger-ui.url: /api/api-docs` 제거 (존재하지 않는 경로로 인한 500 오류)

---

## ✅ 작업 체크리스트
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] 변수명, 클래스명, 메서드명 의미있게 작성

---

## 📎 관련 이슈 / 문서
- 연관 PR: #11, #12 (Swagger 버그 수정 시리즈)