### PR TITLE
[chore] prod 프로파일 추가 - Swagger API 스펙 경로 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,3 @@
+springdoc:
+  swagger-ui:
+    url: /api/api-docs


### PR DESCRIPTION
## 📌 작업 개요
- 배포 환경에서 Swagger UI가 PetStore 기본 페이지로 폴백되는 문제 수정

---

## ✨ 주요 변경 사항
- `application-prod.yml` 추가
  - `springdoc.swagger-ui.url: /api/api-docs` 설정
  - nginx가 `/api` 프리픽스를 유지한 채 백엔드로 프록시하므로 Swagger UI가 스펙을 올바른 경로에서 로드하도록 설정

---

## 💬 기타 참고 사항
- `gifo-deploy` 레포 `docker-compose.yml`의 backend 서비스 환경변수에 아래 두 항목 추가 필요
  - `SPRING_PROFILES_ACTIVE: prod`
  - `API_SERVER_URL: http://43.203.63.240/api`

---

## 📎 관련 이슈 / 문서
- 연관 PR: #11, #12, #13 (Swagger 버그 수정 시리즈)