### PR TITLE
[fix] prod 프로파일 Swagger configUrl 경로 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,3 @@
 springdoc:
-  swagger-ui:
-    url: /api/api-docs
+  api-docs:
+    path: /api/api-docs


### PR DESCRIPTION
## 📌 작업 개요
- 배포 서버에서 Swagger UI가 PetStore 기본 페이지를 표시하는 근본 원인 수정

---

## ✨ 주요 변경 사항
- `application-prod.yml`의 `swagger-ui.url` → `api-docs.path: /api/api-docs` 로 변경

## 💬 기타 참고 사항
**근본 원인**
- Swagger UI는 브라우저에서 `configUrl`을 통해 스펙 설정을 로드함
- springdoc이 `configUrl`을 `/api-docs/swagger-config`로 임베드하는데, nginx는 `/api/*`만 백엔드로 프록시하므로 해당 요청이 백엔드에 도달하지 못함
- `swagger-ui.url` 설정은 이 `configUrl` 문제를 해결하지 못함

**해결 방법**
- `api-docs.path: /api/api-docs`로 설정하면 springdoc이 모든 관련 경로를 `/api/api-docs/...`로 임베드
- 브라우저 요청 흐름: `/api/api-docs/swagger-config` → nginx 프록시 → 백엔드 `/api/api-docs/swagger-config` ✓

---

## 📎 관련 이슈 / 문서
- 연관 PR: #11, #12, #13, #14 (Swagger 버그 수정 시리즈)