### PR TITLE
[chore] CORS 설정 추가

### DIFF
--- a/src/main/java/com/gifo/backend/config/WebConfig.java
+++ b/src/main/java/com/gifo/backend/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.gifo.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://43.203.63.240",
+                        "http://localhost:8080",
+                        "http://localhost:3000"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- Flutter 웹 클라이언트의 API 요청을 허용하기 위한 CORS 설정 추가
- prod 환경 context-path `/api` 설정 (nginx prefix 유지 방식으로 변경에 따른 대응)

---

## ✨ 주요 변경 사항
- `WebConfig.java` 추가 (`config/` 패키지)
  - 허용 출처: `http://43.203.63.240`, `http://localhost:8080`, `http://localhost:3000`
  - 허용 메서드: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`
  - 허용 헤더: 전체 허용
  - `allowCredentials: true`
- `application-prod.yml`에 `server.servlet.context-path: /api` 추가
  - nginx가 `/api` prefix를 제거하지 않도록 변경(`proxy_pass` trailing slash 제거)함에 따라 Spring context-path 설정 필요

---

## 💬 기타 참고 사항
- Flutter 모바일 앱은 CORS 미적용 (브라우저 전용 정책)
- 로컬은 context-path 없이 `localhost:8080/events`로 그대로 동작
- **`gifo-deploy` 레포 nginx 설정 변경 필요**: `proxy_pass http://backend:8080/;` → `proxy_pass http://backend:8080;`

---

## 📎 관련 이슈 / 문서
- 연관 PR: #11 ~ #15 (Swagger 버그 수정 시리즈)