### PR TITLE
[refactor] BaseEntity 도입으로 공통 타임스탬프 필드 중앙화

### DIFF
--- a/src/main/java/com/gifo/backend/entity/BaseEntity.java
+++ b/src/main/java/com/gifo/backend/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.gifo.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/gifo/backend/entity/capsule/Capsule.java
+++ b/src/main/java/com/gifo/backend/entity/capsule/Capsule.java
@@ -1,20 +1,20 @@
 package com.gifo.backend.entity.capsule;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.gift.Gift;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "capsule")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class Capsule {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Capsule extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,9 +31,6 @@ public class Capsule {
 
     @Column(name = "weight")
     private Integer weight;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "capsule", fetch = FetchType.LAZY)

--- a/src/main/java/com/gifo/backend/entity/capsule/CapsuleDraw.java
+++ b/src/main/java/com/gifo/backend/entity/capsule/CapsuleDraw.java
@@ -1,17 +1,16 @@
 package com.gifo.backend.entity.capsule;
 
+import com.gifo.backend.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "capsule_draw")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class CapsuleDraw {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class CapsuleDraw extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +24,4 @@ public class CapsuleDraw {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "capsule_id", nullable = false)
     private Capsule capsule;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/gifo/backend/entity/capsule/CapsuleEvent.java
+++ b/src/main/java/com/gifo/backend/entity/capsule/CapsuleEvent.java
@@ -1,20 +1,20 @@
 package com.gifo.backend.entity.capsule;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.event.BirthdayEvent;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "capsule_event")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class CapsuleEvent {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class CapsuleEvent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,9 +27,6 @@ public class CapsuleEvent {
 
     @Column(name = "max_draw_count")
     private Integer maxDrawCount;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "capsuleEvent", fetch = FetchType.LAZY)

--- a/src/main/java/com/gifo/backend/entity/direct/DirectEvent.java
+++ b/src/main/java/com/gifo/backend/entity/direct/DirectEvent.java
@@ -1,19 +1,18 @@
 package com.gifo.backend.entity.direct;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.event.BirthdayEvent;
 import com.gifo.backend.entity.gift.Gift;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "direct_event")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class DirectEvent {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class DirectEvent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,7 +32,4 @@ public class DirectEvent {
 
     @Column(name = "before_description")
     private String beforeDescription;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/gifo/backend/entity/event/BirthdayEvent.java
+++ b/src/main/java/com/gifo/backend/entity/event/BirthdayEvent.java
@@ -1,10 +1,12 @@
 package com.gifo.backend.entity.event;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.capsule.CapsuleEvent;
 import com.gifo.backend.entity.direct.DirectEvent;
 import com.gifo.backend.entity.quiz.QuizEvent;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,10 +15,9 @@ import java.util.List;
 @Entity
 @Table(name = "birthday_event")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class BirthdayEvent {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class BirthdayEvent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,9 +46,6 @@ public class BirthdayEvent {
 
     @Column(name = "bgm_url")
     private String bgmUrl;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Column(name = "expired_at")
     private LocalDateTime expiredAt;

--- a/src/main/java/com/gifo/backend/entity/event/Memory.java
+++ b/src/main/java/com/gifo/backend/entity/event/Memory.java
@@ -1,17 +1,16 @@
 package com.gifo.backend.entity.event;
 
+import com.gifo.backend.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "memory")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class Memory {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Memory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,7 +32,4 @@ public class Memory {
 
     @Column(name = "sort_order")
     private Integer sortOrder;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/gifo/backend/entity/gift/Gift.java
+++ b/src/main/java/com/gifo/backend/entity/gift/Gift.java
@@ -1,22 +1,22 @@
 package com.gifo.backend.entity.gift;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.capsule.Capsule;
 import com.gifo.backend.entity.direct.DirectEvent;
 import com.gifo.backend.entity.quiz.QuizRewardRule;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "gift")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class Gift {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Gift extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,9 +38,6 @@ public class Gift {
 
     @Column(name = "is_probability_public")
     private Boolean isProbabilityPublic;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "gift", fetch = FetchType.LAZY)

--- a/src/main/java/com/gifo/backend/entity/quiz/Quiz.java
+++ b/src/main/java/com/gifo/backend/entity/quiz/Quiz.java
@@ -1,19 +1,19 @@
 package com.gifo.backend.entity.quiz;
 
+import com.gifo.backend.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "quiz")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class Quiz {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Quiz extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,9 +45,6 @@ public class Quiz {
 
     @Column(name = "sort_order")
     private Integer sortOrder;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "quiz", fetch = FetchType.LAZY)

--- a/src/main/java/com/gifo/backend/entity/quiz/QuizAttempt.java
+++ b/src/main/java/com/gifo/backend/entity/quiz/QuizAttempt.java
@@ -1,17 +1,16 @@
 package com.gifo.backend.entity.quiz;
 
+import com.gifo.backend.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "quiz_attempt")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class QuizAttempt {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class QuizAttempt extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +30,4 @@ public class QuizAttempt {
 
     @Column(name = "is_correct")
     private Boolean isCorrect;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/gifo/backend/entity/quiz/QuizEvent.java
+++ b/src/main/java/com/gifo/backend/entity/quiz/QuizEvent.java
@@ -1,20 +1,20 @@
 package com.gifo.backend.entity.quiz;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.event.BirthdayEvent;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "quiz_event")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class QuizEvent {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class QuizEvent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,9 +28,6 @@ public class QuizEvent {
     @Setter
     @Column(name = "total_attempt")
     private Integer totalAttempt;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "quizEvent", fetch = FetchType.LAZY)

--- a/src/main/java/com/gifo/backend/entity/quiz/QuizRewardRule.java
+++ b/src/main/java/com/gifo/backend/entity/quiz/QuizRewardRule.java
@@ -1,18 +1,17 @@
 package com.gifo.backend.entity.quiz;
 
+import com.gifo.backend.entity.BaseEntity;
 import com.gifo.backend.entity.gift.Gift;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "quiz_reward_rule")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class QuizRewardRule {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class QuizRewardRule extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,7 +28,4 @@ public class QuizRewardRule {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "gift_id", nullable = false)
     private Gift gift;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## 📌 작업 개요
- 11개 엔티티에 중복 선언된 `createdAt` 필드를 `BaseEntity`로 공통화

---

## ✨ 주요 변경 사항
- `entity/BaseEntity.java` 신규 생성
  - `createdAt`, `modifiedAt` 필드 관리
  - `@PrePersist`, `@PreUpdate`로 자동 시간 설정
- 11개 엔티티 수정
  - `createdAt` 필드 제거 및 `extends BaseEntity` 적용
  - `@Builder` → `@SuperBuilder` 전환
  - `@NoArgsConstructor` → `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 적용
- `modifiedAt` 필드 신규 추가 (기존 엔티티에 없던 컬럼)

---

## ✅ 작업 체크리스트
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리
- [x] 컴파일 빌드 성공 확인

---

## 💬 기타 참고 사항
- `modifiedAt` 컬럼이 DB에 신규 추가되므로 스키마 변경 필요
- `@SuperBuilder` 사용으로 엔티티 생성 시 빌더 패턴 동일하게 사용 가능

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호:  #18