### PR TITLE
[fix] CORS 허용 Origin에 gifo.co.kr 추가

### DIFF
--- a/src/main/java/com/gifo/backend/config/WebConfig.java
+++ b/src/main/java/com/gifo/backend/config/WebConfig.java
@@ -13,7 +13,9 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins(
                         "http://43.203.63.240",
                         "http://localhost:8080",
-                        "http://localhost:3000"
+                        "http://localhost:3000",
+                        "https://gifo.co.kr",
+                        "https://www.gifo.co.kr"
                 )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")


### PR DESCRIPTION
## 📌 작업 개요
배포 서버(`https://gifo.co.kr`)에서 API 호출 시 `Invalid CORS request` 오류가 발생하는 문제를 수정합니다.

## ✨ 주요 변경 사항
- `WebConfig.java`의 `allowedOrigins`에 `https://gifo.co.kr`, `https://www.gifo.co.kr` 추가

## 🖼️ 기능 살펴 보기
- 변경 전: `http://43.203.63.240`, `http://localhost:8080`, `http://localhost:3000`만 허용
- 변경 후: 위 목록 + `https://gifo.co.kr`, `https://www.gifo.co.kr` 추가

## ✅ 작업 체크리스트
- [x] `WebConfig.java` allowedOrigins에 운영 도메인 추가

## 📂 테스트 방법
배포 후 Swagger(`https://gifo.co.kr/api/swagger-ui.html`)에서 API 호출 시 CORS 오류 없이 응답 확인

## 💬 기타 참고 사항
기존에 IP(`http://43.203.63.240`)로 직접 접속하는 origin도 남겨두었습니다. 더 이상 사용하지 않는다면 제거해도 됩니다.

## 📎 관련 이슈 / 문서
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 작업**
  * gifo.co.kr 및 www.gifo.co.kr 도메인에서의 API 접근 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->