### PR TITLE
[Refactor] 퀴즈 서버 채점 전환 + 캡슐 선택 후 뽑기 허용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docs/api-spec-open.md
+++ b/docs/api-spec-open.md
@@ -108,11 +108,11 @@ Content-Type: multipart/form-data
 | `CAPSULE_DRAW_LIMIT_EXCEEDED` | 400 | 뽑기 횟수 초과 |
 | `CAPSULE_ALL_DRAWN` | 400 | 모든 캡슐을 이미 뽑음 |
 | `CAPSULE_DRAW_NOT_FOUND` | 404 | 해당 캡슐 뽑기 이력을 찾을 수 없음 |
-| `CAPSULE_ALREADY_SELECTED` | 400 | 이미 캡슐을 선택함 |
 | `QUIZ_NOT_FOUND` | 404 | 퀴즈 이벤트가 없음 |
 | `QUIZ_ALREADY_ANSWERED` | 400 | 이미 답변한 문제 |
-| `QUIZ_ALL_ANSWERED` | 400 | 모든 문제를 이미 풀었음 |
+| `QUIZ_NOT_ALL_ANSWERED` | 400 | 모든 문제를 아직 풀지 않음 |
 | `QUIZ_QUESTION_NOT_FOUND` | 404 | 해당 퀴즈 문제를 찾을 수 없음 |
+| `QUIZ_NO_ATTEMPTS_LEFT` | 400 | 시도 횟수 소진 |
 | `INVALID_ARGUMENT` | 400 | 잘못된 요청 |
 
 ---
@@ -215,7 +215,7 @@ GET /events/{eventUrl}
 |------|------|------|
 | `playCount` | int | 총 뽑기 횟수 (이벤트 생성 시 설정) |
 | `remainingDrawCount` | int | 남은 뽑기 횟수 |
-| `selected` | boolean | 선택 완료 여부 (`true`면 뽑기 불가, 선택 변경은 가능) |
+| `selected` | boolean | 선택 완료 여부 (선택 후에도 뽑기 가능, 선택 변경도 가능) |
 | `list` | Array | 남은 캡슐 목록 (이미 뽑힌 캡슐은 제외됨) |
 | `list[].itemName` | String | 선물 이름 |
 | `list[].imageUrl` | String | 선물 이미지 URL |
@@ -257,7 +257,6 @@ GET /events/{eventUrl}
         "description": null,
         "hint": "어제 저녁에도 먹었어요!",
         "options": ["치킨", "마라탕", "초밥", "삼겹살", "파스타"],
-        "answer": ["치킨"],
         "playLimit": 3
       },
       {
@@ -268,7 +267,6 @@ GET /events/{eventUrl}
         "description": null,
         "hint": "반려동물이 있긴 해요",
         "options": ["O", "X"],
-        "answer": ["O"],
         "playLimit": 2
       },
       {
@@ -279,7 +277,6 @@ GET /events/{eventUrl}
         "description": null,
         "hint": "강남역 근처의 유명한 카페 브랜드입니다.",
         "options": [],
-        "answer": ["스타벅스", "스벅"],
         "playLimit": 3
       }
     ],
@@ -308,19 +305,20 @@ GET /events/{eventUrl}
 | `list[].description` | String | 문제 설명 (없으면 `null`) |
 | `list[].hint` | String | 힌트 텍스트 |
 | `list[].options` | Array\<String\> | 선택지 목록 (`text` 타입은 빈 배열) |
-| `list[].answer` | Array\<String\> | 정답 목록 (주관식은 허용 답안 여러 개 가능) |
 | `list[].playLimit` | int | 문항별 시도 제한 횟수 |
 | `answerHistory` | Array | 이미 푼 문제의 정답/오답 기록 (재접속 시 복원용) |
 | `answerHistory[].quizId` | Long | 문제 PK |
 | `answerHistory[].correct` | boolean | 정답 여부 |
 
-**퀴즈 채점 플로우 (프론트에서 처리):**
+**퀴즈 채점 플로우 (서버에서 처리):**
 1. `currentQuizIndex`에 해당하는 문제를 표시
 2. `remainingAttempts`가 있으면 해당 횟수부터 이어서 시도, `null`이면 `playLimit`부터 시작
-3. `answer` 배열과 대소문자 무시 비교로 정답 판별
-4. 정답 → `POST /quiz/answer { quizId, correct: true, remainingAttempts: 0 }` → 다음 문항으로
-5. 오답 → 남은 기회 차감, 0이면 `POST /quiz/answer { quizId, correct: false, remainingAttempts: 0 }` → 다음 문항으로
+3. 사용자가 답안을 선택/입력하면 `POST /quiz/answer { quizId, selectedAnswer }` 호출
+4. 서버가 채점 → 정답이면 `correct: true, remainingAttempts: 0` 반환, 다음 문항으로
+5. 오답이면 서버가 `remainingAttempts` 차감 → 0이면 해당 문항 종료(correct: false), 다음 문항으로
 6. 모든 문항 완료 → `POST /quiz/result` → 서버가 정답 수 계산하여 성공/실패 보상 반환
+
+> **참고:** 정답은 서버에서만 보유하며 클라이언트에 노출하지 않습니다.
 
 ---
 
@@ -399,7 +397,6 @@ POST /events/{eventUrl}/capsules/draw
 | 뽑기 횟수 초과 | `CAPSULE_DRAW_LIMIT_EXCEEDED` | 400 |
 | 모든 캡슐 소진 | `CAPSULE_ALL_DRAWN` | 400 |
 | 캡슐 이벤트 없음 | `CAPSULE_NOT_FOUND` | 404 |
-| 이미 선택 완료 | `CAPSULE_ALREADY_SELECTED` | 400 |
 
 ### 참고
 
@@ -407,6 +404,7 @@ POST /events/{eventUrl}/capsules/draw
 - 재접속 시에는 `GET /events/{eventUrl}`의 `drawHistory`에서 복원합니다.
 - 뽑기 후 다시 `GET /events/{eventUrl}`을 호출하면 `remainingDrawCount`가 감소하고, 뽑힌 캡슐은 `list`에서 제거됩니다.
 - 남은 캡슐의 확률(`percent`)은 자동으로 재계산됩니다.
+- **선택(select) 후에도 남은 횟수가 있으면 뽑기를 계속할 수 있습니다.**
 
 ---
 
@@ -466,9 +464,12 @@ POST /events/{eventUrl}/capsules/select
 
 ---
 
-## 4. 퀴즈 문제별 결과 저장
+## 4. 퀴즈 답안 제출 (서버 채점)
 
-문제 1개의 풀이 결과(정답/오답)를 저장합니다. 정답을 맞추거나 playLimit을 소진했을 때 호출합니다.
+매 시도마다 호출합니다. 서버가 채점하고 `remainingAttempts`를 관리합니다.
+- 정답 → `QuizAnswer` 저장 + 다음 문제로
+- 오답 + 횟수 남음 → `remainingAttempts` 차감
+- 오답 + 횟수 소진 → `QuizAnswer(correct=false)` 저장 + 다음 문제로
 
 ### Request
 
@@ -485,26 +486,25 @@ POST /events/{eventUrl}/quiz/answer
 ```json
 {
   "quizId": 1,
-  "correct": true,
-  "remainingAttempts": 0
+  "selectedAnswer": "치킨"
 }
 ```
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|------|------|
 | `quizId` | Long | O | 문제 PK |
-| `correct` | boolean | O | 정답 여부 |
-| `remainingAttempts` | int | O | 현재 문제의 남은 시도 횟수 (재접속 시 이어하기용, 완료 시 0) |
+| `selectedAnswer` | String | O | 사용자가 선택/입력한 답안 |
 
 ### Response (200 OK)
 
 ```json
 {
   "code": "SUCCESS",
-  "message": "문제 결과 저장 성공",
+  "message": "답안 제출 성공",
   "data": {
     "quizId": 1,
     "correct": true,
+    "remainingAttempts": 0,
     "currentQuizIndex": 1
   }
 }
@@ -512,25 +512,26 @@ POST /events/{eventUrl}/quiz/answer
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| `quizId` | Long | 저장된 문제 PK |
-| `correct` | boolean | 정답 여부 |
-| `currentQuizIndex` | int | 다음에 풀어야 할 문제 인덱스 |
+| `quizId` | Long | 제출한 문제 PK |
+| `correct` | boolean | 서버 채점 결과 |
+| `remainingAttempts` | int | 남은 시도 횟수 (0이면 해당 문제 종료 — 정답이든 횟수 소진이든) |
+| `currentQuizIndex` | int | 다음에 풀어야 할 문제 인덱스 (`remainingAttempts > 0`이면 현재 문제 유지) |
 
 ### 에러 케이스
 
 | 상황 | 에러 코드 | HTTP |
 |------|----------|------|
 | 이미 답변한 문제 | `QUIZ_ALREADY_ANSWERED` | 400 |
+| 시도 횟수 소진 | `QUIZ_NO_ATTEMPTS_LEFT` | 400 |
 | 퀴즈 이벤트 없음 | `QUIZ_NOT_FOUND` | 404 |
 | 문제가 없음 | `QUIZ_QUESTION_NOT_FOUND` | 404 |
-| quizId 누락 | `VALIDATION_ERROR` | 400 |
-| remainingAttempts 음수 | `INVALID_ARGUMENT` | 400 |
+| quizId/selectedAnswer 누락 | `VALIDATION_ERROR` | 400 |
 
 ### 참고
 
-- 프론트에서 채점 후 정답/오답 결과만 서버에 전송합니다.
-- 재접속 시 `GET /events/{eventUrl}`의 `answerHistory`로 풀이 기록이 복원됩니다.
-- `remainingAttempts`는 문제 풀다가 중간에 나갔을 때 이어하기용으로 저장됩니다.
+- 서버가 `selectedAnswer`와 DB의 정답을 대소문자 무시 + trim 비교로 채점합니다.
+- `remainingAttempts`는 서버가 관리합니다. 첫 시도 시 `playLimit`으로 초기화됩니다.
+- 재접속 시 `GET /events/{eventUrl}`의 `remainingAttempts`로 중간 상태가 복원됩니다.
 
 ---
 
@@ -745,12 +746,14 @@ Content-Type: multipart/form-data
 2-A. 캡슐 뽑기 플로우
    → POST /events/{eventUrl}/capsules/draw (1회 뽑기)
    → 결과를 프론트 로컬 히스토리에 push, 오른쪽에 "~~를 뽑았습니다" 표시
-   → 남은 횟수만큼 반복 또는 원하는 선물이 나오면 중단
-   → POST /events/{eventUrl}/capsules/select로 최종 선물 선택 (이미 선택한 경우에도 변경 가능)
+   → POST /events/{eventUrl}/capsules/select로 선물 선택 (언제든 변경 가능)
+   → 선택 후에도 남은 횟수가 있으면 계속 뽑기 가능
+   → 뽑기와 선택을 자유롭게 반복 (선택이 뽑기를 차단하지 않음)
 
 2-B. 퀴즈 플로우
-   → 프론트에서 문항별 채점 (answer 비교, playLimit 재시도)
-   → 정답 또는 playLimit 소진 시 POST /events/{eventUrl}/quiz/answer
+   → 매 시도마다 POST /events/{eventUrl}/quiz/answer { quizId, selectedAnswer }
+   → 서버가 채점 + remainingAttempts 관리
+   → 정답 또는 playLimit 소진 시 자동으로 다음 문항 이동
    → 모든 문항 완료 후 POST /events/{eventUrl}/quiz/result
    → 서버가 정답 수 계산 → 성공/실패 보상 반환
 

--- a/src/main/java/com/gifo/backend/controller/quiz/QuizController.java
+++ b/src/main/java/com/gifo/backend/controller/quiz/QuizController.java
@@ -20,17 +20,17 @@ public class QuizController {
     private final QuizService quizService;
 
     /**
-     * POST /events/{eventUrl}/quiz/answer - 문제별 결과 저장
-     * 정답을 맞추거나 playLimit 소진 시 호출
+     * POST /events/{eventUrl}/quiz/answer - 답안 제출
+     * 매 시도마다 호출 → 서버가 채점 + remainingAttempts 관리
      */
     @PostMapping("/{eventUrl}/quiz/answer")
-    @Operation(summary = "퀴즈 문제별 결과 저장", description = "문제 1개의 풀이 결과(정답/오답)를 저장합니다.")
-    public ResponseEntity<ApiResponse<QuizResponse.Answer>> saveAnswer(
+    @Operation(summary = "퀴즈 답안 제출", description = "답안을 제출하면 서버가 채점하고 남은 시도 횟수를 관리합니다.")
+    public ResponseEntity<ApiResponse<QuizResponse.Answer>> submitAnswer(
             @PathVariable String eventUrl,
             @Valid @RequestBody QuizRequest.Answer request) {
 
-        QuizResponse.Answer response = quizService.saveAnswerWithAttempts(eventUrl, request);
-        return ResponseEntity.ok(ApiResponse.success("문제 결과 저장 성공", response));
+        QuizResponse.Answer response = quizService.submitAnswer(eventUrl, request);
+        return ResponseEntity.ok(ApiResponse.success("답안 제출 성공", response));
     }
 
     /**

--- a/src/main/java/com/gifo/backend/dto/event/EventResponse.java
+++ b/src/main/java/com/gifo/backend/dto/event/EventResponse.java
@@ -117,7 +117,7 @@ public class EventResponse {
      * 퀴즈 문항 1개
      * type: "multiple_choice" | "ox" | "text" (프론트 매핑용)
      * options: 선택지 목록 (주관식은 빈 리스트)
-     * answer: 정답 목록
+     * 정답은 서버에서 채점하므로 클라이언트에 노출하지 않음
      */
     public record QuizItem(
             Long quizId,
@@ -127,7 +127,6 @@ public class EventResponse {
             String description,
             String hint,
             List<String> options,
-            List<String> answer,
             int playLimit
     ) {}
 

--- a/src/main/java/com/gifo/backend/dto/quiz/QuizRequest.java
+++ b/src/main/java/com/gifo/backend/dto/quiz/QuizRequest.java
@@ -1,6 +1,6 @@
 package com.gifo.backend.dto.quiz;
 
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -10,19 +10,18 @@ public class QuizRequest {
 
     /**
      * POST /events/{eventUrl}/quiz/result 요청
-     * 프론트에서 채점 완료 후 호출 (서버가 DB에서 정답 수 계산)
+     * 모든 문제 완료 후 호출 (서버가 DB에서 정답 수 계산)
      */
     public record Result(int correctCount) {}
 
     /**
      * POST /events/{eventUrl}/quiz/answer 요청
-     * 문제 1개 풀이 결과 저장
+     * 매 시도마다 호출 — 서버가 채점 + remainingAttempts 관리
      */
     public record Answer(
             @NotNull(message = "quizId는 필수입니다.")
             Long quizId,
-            boolean correct,
-            @Min(value = 0, message = "시도 횟수는 0 이상이어야 합니다.")
-            int remainingAttempts
+            @NotBlank(message = "selectedAnswer는 필수입니다.")
+            String selectedAnswer
     ) {}
 }

--- a/src/main/java/com/gifo/backend/dto/quiz/QuizResponse.java
+++ b/src/main/java/com/gifo/backend/dto/quiz/QuizResponse.java
@@ -16,11 +16,13 @@ public class QuizResponse {
 
     /**
      * POST /events/{eventUrl}/quiz/answer 응답
-     * 문제별 결과 저장 확인 + 다음 문제 인덱스
+     * 서버 채점 결과 + 남은 시도 횟수
+     * remainingAttempts=0이면 해당 문제 종료 (정답이든 횟수 소진이든)
      */
     public record Answer(
             Long quizId,
             boolean correct,
+            int remainingAttempts,
             int currentQuizIndex
     ) {}
 }

--- a/src/main/java/com/gifo/backend/global/ErrorCode.java
+++ b/src/main/java/com/gifo/backend/global/ErrorCode.java
@@ -33,7 +33,6 @@ public enum ErrorCode {
     CAPSULE_DRAW_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "뽑기 가능 횟수를 초과했습니다."),
     CAPSULE_ALL_DRAWN(HttpStatus.BAD_REQUEST, "모든 캡슐을 이미 뽑았습니다."),
     CAPSULE_DRAW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 캡슐 뽑기 이력을 찾을 수 없습니다."),
-    CAPSULE_ALREADY_SELECTED(HttpStatus.BAD_REQUEST, "이미 캡슐을 선택했습니다."),
 
     // 퀴즈 도메인
     QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈 이벤트를 찾을 수 없습니다."),
@@ -41,6 +40,7 @@ public enum ErrorCode {
     QUIZ_ALL_ANSWERED(HttpStatus.BAD_REQUEST, "모든 문제를 이미 풀었습니다."),
     QUIZ_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 퀴즈 문제를 찾을 수 없습니다."),
     QUIZ_NOT_ALL_ANSWERED(HttpStatus.BAD_REQUEST, "모든 문제를 풀어야 결과를 확인할 수 있습니다."),
+    QUIZ_NO_ATTEMPTS_LEFT(HttpStatus.BAD_REQUEST, "시도 횟수를 모두 소진했습니다."),
 
     // 스토리지 도메인
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다. JPEG, PNG만 업로드 가능합니다."),

--- a/src/main/java/com/gifo/backend/repository/capsule/CapsuleDrawRepository.java
+++ b/src/main/java/com/gifo/backend/repository/capsule/CapsuleDrawRepository.java
@@ -28,7 +28,5 @@ public interface CapsuleDrawRepository extends JpaRepository<CapsuleDraw, Long> 
 
     List<CapsuleDraw> findByCapsuleEventAndSelectedTrue(CapsuleEvent capsuleEvent);
 
-    boolean existsByCapsuleEventAndSelectedTrue(CapsuleEvent capsuleEvent);
-
     void deleteByCapsuleEvent(CapsuleEvent capsuleEvent);
 }

--- a/src/main/java/com/gifo/backend/service/capsule/CapsuleService.java
+++ b/src/main/java/com/gifo/backend/service/capsule/CapsuleService.java
@@ -52,11 +52,6 @@ public class CapsuleService {
             throw new CapsuleException(ErrorCode.CAPSULE_NOT_FOUND);
         }
 
-        // 이미 선택 완료된 경우 뽑기 불가
-        if (capsuleDrawRepository.existsByCapsuleEventAndSelectedTrue(capsuleEvent)) {
-            throw new CapsuleException(ErrorCode.CAPSULE_ALREADY_SELECTED);
-        }
-
         // 뽑기 횟수 초과 검증
         long drawCount = capsuleDrawRepository.countByCapsuleEvent(capsuleEvent);
         if (drawCount >= capsuleEvent.getMaxDrawCount()) {

--- a/src/main/java/com/gifo/backend/service/event/BirthdayEventService.java
+++ b/src/main/java/com/gifo/backend/service/event/BirthdayEventService.java
@@ -229,32 +229,15 @@ public class BirthdayEventService {
                 successReward, failReward, quizItems, answerHistory);
     }
 
-    // 퀴즈 문항 빌드: 타입별 선택지 + 정답 구성
-    // OBJECTIVE: 모든 선택지 + 정답 표시
-    // OX: "O","X" 선택지 + 정답 표시
-    // SUBJECTIVE: 빈 선택지 + 정답 텍스트 목록
+    // 퀴즈 문항 빌드: 타입별 선택지 구성 (정답은 서버 채점이므로 미노출)
     private EventResponse.QuizItem buildQuizItem(Quiz quiz) {
         List<QuizChoice> choices = quiz.getQuizChoices();
 
-        List<String> options;
-        List<String> answers;
-
-        switch (quiz.getQuizType()) {
-            case OBJECTIVE -> {
-                options = choices.stream().map(QuizChoice::getChoiceText).toList();
-                answers = choices.stream().filter(QuizChoice::getIsCorrect)
-                        .map(QuizChoice::getChoiceText).toList();
-            }
-            case OX -> {
-                options = List.of("O", "X");
-                answers = choices.stream().filter(QuizChoice::getIsCorrect)
-                        .map(QuizChoice::getChoiceText).toList();
-            }
-            default -> { // SUBJECTIVE
-                options = List.of();
-                answers = choices.stream().map(QuizChoice::getChoiceText).toList();
-            }
-        }
+        List<String> options = switch (quiz.getQuizType()) {
+            case OBJECTIVE -> choices.stream().map(QuizChoice::getChoiceText).toList();
+            case OX -> List.of("O", "X");
+            case SUBJECTIVE -> List.of();
+        };
 
         return new EventResponse.QuizItem(
                 quiz.getQuizId(),
@@ -264,7 +247,6 @@ public class BirthdayEventService {
                 quiz.getDescription(),
                 quiz.getHint(),
                 options,
-                answers,
                 quiz.getPlayLimit()
         );
     }

--- a/src/main/java/com/gifo/backend/service/quiz/QuizService.java
+++ b/src/main/java/com/gifo/backend/service/quiz/QuizService.java
@@ -3,26 +3,26 @@ package com.gifo.backend.service.quiz;
 import com.gifo.backend.dto.quiz.QuizRequest;
 import com.gifo.backend.dto.quiz.QuizResponse;
 import com.gifo.backend.entity.event.BirthdayEvent;
-import com.gifo.backend.entity.quiz.Quiz;
-import com.gifo.backend.entity.quiz.QuizAnswer;
-import com.gifo.backend.entity.quiz.QuizEvent;
+import com.gifo.backend.entity.quiz.*;
 import com.gifo.backend.global.ErrorCode;
 import com.gifo.backend.global.exception.quiz.QuizException;
 import com.gifo.backend.global.util.EntityFinder;
-import com.gifo.backend.repository.quiz.QuizAnswerRepository;
-import com.gifo.backend.repository.quiz.QuizEventRepository;
-import com.gifo.backend.repository.quiz.QuizRepository;
-import com.gifo.backend.repository.quiz.QuizRewardRuleRepository;
+import com.gifo.backend.repository.quiz.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * 퀴즈 비즈니스 로직
  *
- * 1. POST /events/{eventUrl}/quiz/answer — 문제별 결과 저장
- *    정답을 맞추거나 playLimit 소진 시 호출 → QuizAnswer 저장 + remainingAttempts 관리
+ * 1. POST /events/{eventUrl}/quiz/answer — 매 시도마다 호출
+ *    서버가 채점 + remainingAttempts 관리
+ *    - 정답 → QuizAnswer 저장 + 다음 문제로
+ *    - 오답 + 횟수 남음 → remainingAttempts 차감
+ *    - 오답 + 횟수 소진 → QuizAnswer(correct=false) 저장 + 다음 문제로
  *
  * 2. POST /events/{eventUrl}/quiz/result — 최종 보상 판정
  *    모든 문제 완료 후 호출 → 서버가 DB에서 정답 수 계산 → 성공/실패 보상 반환
@@ -37,22 +37,13 @@ public class QuizService {
     private final QuizEventRepository quizEventRepository;
     private final QuizAnswerRepository quizAnswerRepository;
     private final QuizRewardRuleRepository quizRewardRuleRepository;
+    private final QuizChoiceRepository quizChoiceRepository;
 
     /**
-     * 문제별 결과 저장 + 남은 시도 횟수 업데이트 (단일 트랜잭션)
-     * 컨트롤러에서 이 메서드를 호출하면 remainingAttempts 업데이트와 답변 저장이
-     * 같은 트랜잭션에서 실행되어 부분 커밋 문제를 방지합니다.
+     * 답안 제출 (매 시도마다 호출)
+     * 서버가 채점하고 remainingAttempts를 관리합니다.
      */
-    public QuizResponse.Answer saveAnswerWithAttempts(String eventUrl, QuizRequest.Answer request) {
-        updateRemainingAttempts(eventUrl, request.remainingAttempts());
-        return saveAnswer(eventUrl, request);
-    }
-
-    /**
-     * 문제별 결과 저장
-     * 프론트에서 정답을 맞추거나 playLimit을 소진했을 때 호출
-     */
-    public QuizResponse.Answer saveAnswer(String eventUrl, QuizRequest.Answer request) {
+    public QuizResponse.Answer submitAnswer(String eventUrl, QuizRequest.Answer request) {
         BirthdayEvent event = entityFinder.getEventByUrlOrThrow(eventUrl);
 
         QuizEvent quizEvent = event.getQuizEvent();
@@ -64,28 +55,84 @@ public class QuizService {
         Quiz quiz = quizRepository.findByQuizEventAndQuizId(quizEvent, request.quizId())
                 .orElseThrow(() -> new QuizException(ErrorCode.QUIZ_QUESTION_NOT_FOUND));
 
-        // 이미 답변한 문제인지 검증
+        // 이미 답변 완료된 문제인지 검증
         if (quizAnswerRepository.existsByQuizEventAndQuiz(quizEvent, quiz)) {
             throw new QuizException(ErrorCode.QUIZ_ALREADY_ANSWERED);
         }
 
-        // QuizAnswer 저장 (unique constraint 위반 시 비즈니스 예외로 변환)
+        // remainingAttempts 초기화 (첫 시도 시 playLimit으로 세팅)
+        Integer remaining = quizEvent.getCurrentQuizRemainingAttempts();
+        if (remaining == null) {
+            remaining = quiz.getPlayLimit();
+        }
+
+        // 시도 횟수 소진 검증
+        if (remaining <= 0) {
+            throw new QuizException(ErrorCode.QUIZ_NO_ATTEMPTS_LEFT);
+        }
+
+        // 서버 채점: selectedAnswer와 DB 정답 비교
+        boolean correct = gradeAnswer(quiz, request.selectedAnswer());
+
+        if (correct) {
+            // 정답 → QuizAnswer 저장 + remainingAttempts 초기화
+            saveQuizAnswer(quizEvent, quiz, true);
+            quizEvent.setCurrentQuizRemainingAttempts(null);
+
+            int currentQuizIndex = (int) quizAnswerRepository.countByQuizEvent(quizEvent);
+            return new QuizResponse.Answer(request.quizId(), true, 0, currentQuizIndex);
+        } else {
+            // 오답 → 횟수 차감
+            remaining -= 1;
+
+            if (remaining <= 0) {
+                // 횟수 소진 → QuizAnswer(correct=false) 저장 + remainingAttempts 초기화
+                saveQuizAnswer(quizEvent, quiz, false);
+                quizEvent.setCurrentQuizRemainingAttempts(null);
+
+                int currentQuizIndex = (int) quizAnswerRepository.countByQuizEvent(quizEvent);
+                return new QuizResponse.Answer(request.quizId(), false, 0, currentQuizIndex);
+            } else {
+                // 아직 기회 남음 → remainingAttempts만 업데이트
+                quizEvent.setCurrentQuizRemainingAttempts(remaining);
+
+                int currentQuizIndex = (int) quizAnswerRepository.countByQuizEvent(quizEvent);
+                return new QuizResponse.Answer(request.quizId(), false, remaining, currentQuizIndex);
+            }
+        }
+    }
+
+    /**
+     * 서버 채점: 퀴즈 타입별 정답 비교
+     * - OBJECTIVE / OX: isCorrect=true인 QuizChoice의 choiceText와 비교
+     * - SUBJECTIVE: 모든 QuizChoice(허용 답안)와 대소문자 무시 + trim 비교
+     */
+    private boolean gradeAnswer(Quiz quiz, String selectedAnswer) {
+        String trimmed = selectedAnswer.trim();
+        List<QuizChoice> choices = quizChoiceRepository.findByQuiz(quiz);
+
+        return switch (quiz.getQuizType()) {
+            case OBJECTIVE, OX -> choices.stream()
+                    .filter(QuizChoice::getIsCorrect)
+                    .anyMatch(c -> c.getChoiceText().trim().equalsIgnoreCase(trimmed));
+            case SUBJECTIVE -> choices.stream()
+                    .anyMatch(c -> c.getChoiceText().trim().equalsIgnoreCase(trimmed));
+        };
+    }
+
+    /**
+     * QuizAnswer 저장 (unique constraint 위반 시 비즈니스 예외로 변환)
+     */
+    private void saveQuizAnswer(QuizEvent quizEvent, Quiz quiz, boolean correct) {
         try {
             quizAnswerRepository.saveAndFlush(QuizAnswer.builder()
                     .quizEvent(quizEvent)
                     .quiz(quiz)
-                    .correct(request.correct())
+                    .correct(correct)
                     .build());
         } catch (DataIntegrityViolationException e) {
             throw new QuizException(ErrorCode.QUIZ_ALREADY_ANSWERED);
         }
-
-        // 문제가 완료되었으므로 remainingAttempts null로 초기화
-        quizEvent.setCurrentQuizRemainingAttempts(null);
-
-        int currentQuizIndex = (int) quizAnswerRepository.countByQuizEvent(quizEvent);
-
-        return new QuizResponse.Answer(request.quizId(), request.correct(), currentQuizIndex);
     }
 
     /**
@@ -124,24 +171,5 @@ public class QuizService {
         quizEvent.setLastSuccess(success);
 
         return new QuizResponse.Result(correctCount, success);
-    }
-
-    /**
-     * 현재 풀고 있는 문제의 남은 시도 횟수 업데이트
-     * 프론트에서 오답 시도할 때마다 호출하여 재접속 시 이어하기용으로 저장
-     */
-    public void updateRemainingAttempts(String eventUrl, int remainingAttempts) {
-        if (remainingAttempts < 0) {
-            throw new QuizException(ErrorCode.INVALID_ARGUMENT);
-        }
-
-        BirthdayEvent event = entityFinder.getEventByUrlOrThrow(eventUrl);
-
-        QuizEvent quizEvent = event.getQuizEvent();
-        if (quizEvent == null) {
-            throw new QuizException(ErrorCode.QUIZ_NOT_FOUND);
-        }
-
-        quizEvent.setCurrentQuizRemainingAttempts(remainingAttempts);
     }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,3 +13,12 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update
+
+# TODO: StorageConfig가 @Value로 주입받는 값들 — 테스트에서 S3 실사용 안 하므로 더미값
+storage:
+  access-key-id: test
+  secret-access-key: test
+  bucket-name: test-bucket
+  region: ap-northeast-2
+  cdn-domain: https://test-cdn.example.com
+  endpoint: https://test-endpoint.example.com

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,7 +12,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
 
 # TODO: StorageConfig가 @Value로 주입받는 값들 — 테스트에서 S3 실사용 안 하므로 더미값
 storage:

--- a/src/test/java/com/gifo/backend/integration/CapsuleFullFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/CapsuleFullFlowTest.java
@@ -1,0 +1,172 @@
+package com.gifo.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gifo.backend.entity.capsule.Capsule;
+import com.gifo.backend.entity.capsule.CapsuleEvent;
+import com.gifo.backend.entity.event.BirthdayEvent;
+import com.gifo.backend.entity.event.EventStatus;
+import com.gifo.backend.entity.gift.Gift;
+import com.gifo.backend.repository.capsule.CapsuleEventRepository;
+import com.gifo.backend.repository.capsule.CapsuleRepository;
+import com.gifo.backend.repository.event.BirthdayEventRepository;
+import com.gifo.backend.repository.gift.GiftRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import jakarta.persistence.EntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 캡슐 뽑기 전체 플로우 시나리오 테스트
+ *
+ * 캡슐 5개, maxDrawCount=5
+ * 3번 뽑기 → 그 중 1개 select → 2번 더 뽑기 → 새로 뽑힌 것 중 하나로 select 변경
+ * select 후에도 뽑기가 차단되지 않는 것을 검증
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CapsuleFullFlowTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired EntityManager em;
+    @Autowired BirthdayEventRepository birthdayEventRepository;
+    @Autowired CapsuleEventRepository capsuleEventRepository;
+    @Autowired CapsuleRepository capsuleRepository;
+    @Autowired GiftRepository giftRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private String eventUrl;
+
+    @BeforeEach
+    void setUp() {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("CAP_FLOW").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        eventUrl = event.getEventUrl();
+
+        // 캡슐 이벤트: 최대 5회 뽑기
+        CapsuleEvent capsuleEvent = capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(5).build());
+
+        // 선물 5개 + 캡슐 5개
+        String[] names = {"에어팟 프로", "양말 세트", "기프티콘", "텀블러", "쿠션"};
+        String[] images = {"airpods.jpg", "socks.jpg", "gifticon.jpg", "tumbler.jpg", "cushion.jpg"};
+        int[] weights = {30, 25, 20, 15, 10};
+
+        for (int i = 0; i < 5; i++) {
+            Gift gift = giftRepository.save(Gift.builder()
+                    .giftName(names[i]).giftImageUrl("https://img/" + images[i])
+                    .description(names[i] + " 선물!").isProbabilityPublic(true).build());
+            capsuleRepository.save(Capsule.builder()
+                    .capsuleEvent(capsuleEvent).gift(gift).weight(weights[i]).build());
+        }
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("전체 시나리오: 3번 뽑기 → select → 2번 더 뽑기 → 새 캡슐로 select 변경")
+    void fullFlow_drawSelectDrawReselect() throws Exception {
+        // ── 초기 상태 확인 ──
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.gacha.playCount").value(5))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(5))
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(false))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(0));
+
+        // ── 1~3번째 뽑기 ──
+        Long[] drawnCapsuleIds = new Long[5];
+
+        for (int i = 0; i < 3; i++) {
+            String result = mockMvc.perform(post("/events/{eventUrl}/capsules/draw", eventUrl))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.capsuleId").isNumber())
+                    .andReturn().getResponse().getContentAsString();
+            drawnCapsuleIds[i] = objectMapper.readTree(result).path("data").path("capsuleId").asLong();
+        }
+
+        // 3번 뽑기 후 상태 확인: remainingDrawCount=2, drawHistory=3건
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(2))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(3))
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(false));
+
+        // ── 첫 번째 select: 1번째로 뽑은 캡슐 선택 ──
+        mockMvc.perform(post("/events/{eventUrl}/capsules/select", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"capsuleId\":" + drawnCapsuleIds[0] + "}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.giftName").isString());
+
+        // select 후 상태: selected=true, remainingDrawCount=2 (select가 뽑기를 차단하지 않음)
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(true))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(2));
+
+        // ── select 이후에도 4~5번째 뽑기 가능 ──
+        for (int i = 3; i < 5; i++) {
+            String result = mockMvc.perform(post("/events/{eventUrl}/capsules/draw", eventUrl))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.capsuleId").isNumber())
+                    .andReturn().getResponse().getContentAsString();
+            drawnCapsuleIds[i] = objectMapper.readTree(result).path("data").path("capsuleId").asLong();
+        }
+
+        // 5번 모두 뽑은 후 상태: remainingDrawCount=0, drawHistory=5건
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(0))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(5))
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(true));
+
+        // 6번째 뽑기 시도 → 횟수 초과 에러
+        mockMvc.perform(post("/events/{eventUrl}/capsules/draw", eventUrl))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CAPSULE_DRAW_LIMIT_EXCEEDED"));
+
+        // ── select 변경: 새로 뽑은 4번째 캡슐로 변경 ──
+        mockMvc.perform(post("/events/{eventUrl}/capsules/select", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"capsuleId\":" + drawnCapsuleIds[3] + "}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.giftName").isString());
+
+        // 최종 상태 확인: selected=true, drawHistory에서 selected=true는 정확히 1개
+        String finalState = mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(true))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(5))
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode drawHistory = objectMapper.readTree(finalState)
+                .path("data").path("content").path("gacha").path("drawHistory");
+        long selectedCount = 0;
+        Long selectedCapsuleId = null;
+        for (JsonNode draw : drawHistory) {
+            if (draw.path("selected").asBoolean()) {
+                selectedCount++;
+                selectedCapsuleId = draw.path("capsuleId").asLong();
+            }
+        }
+        Assertions.assertEquals(1, selectedCount, "selected=true인 캡슐은 정확히 1개여야 합니다");
+        Assertions.assertEquals(drawnCapsuleIds[3], selectedCapsuleId,
+                "4번째로 뽑은 캡슐이 최종 선택되어야 합니다");
+    }
+}

--- a/src/test/java/com/gifo/backend/integration/EdgeCaseTest.java
+++ b/src/test/java/com/gifo/backend/integration/EdgeCaseTest.java
@@ -1,0 +1,628 @@
+package com.gifo.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gifo.backend.entity.capsule.Capsule;
+import com.gifo.backend.entity.capsule.CapsuleEvent;
+import com.gifo.backend.entity.event.BirthdayEvent;
+import com.gifo.backend.entity.event.EventStatus;
+import com.gifo.backend.entity.gift.Gift;
+import com.gifo.backend.entity.quiz.*;
+import com.gifo.backend.repository.capsule.CapsuleEventRepository;
+import com.gifo.backend.repository.capsule.CapsuleRepository;
+import com.gifo.backend.repository.event.BirthdayEventRepository;
+import com.gifo.backend.repository.gift.GiftRepository;
+import com.gifo.backend.repository.quiz.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import jakarta.persistence.EntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 엣지 케이스 통합 테스트
+ *
+ * 캡슐/퀴즈/이벤트 전반의 경계 조건 및 에러 시나리오를 검증합니다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class EdgeCaseTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired EntityManager em;
+    @Autowired BirthdayEventRepository birthdayEventRepository;
+    @Autowired CapsuleEventRepository capsuleEventRepository;
+    @Autowired CapsuleRepository capsuleRepository;
+    @Autowired GiftRepository giftRepository;
+    @Autowired QuizEventRepository quizEventRepository;
+    @Autowired QuizRepository quizRepository;
+    @Autowired QuizChoiceRepository quizChoiceRepository;
+    @Autowired QuizRewardRuleRepository quizRewardRuleRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // ══════════════════════════════════════════════
+    // 1. CAPSULE_ALL_DRAWN — maxDrawCount > 캡슐 개수
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("캡슐: maxDrawCount > 캡슐 개수일 때 모든 캡슐 소진 → CAPSULE_ALL_DRAWN")
+    void capsule_allDrawn() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_CAP1").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        // 캡슐 2개인데 maxDrawCount=5
+        CapsuleEvent capsuleEvent = capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(5).build());
+
+        for (int i = 0; i < 2; i++) {
+            Gift gift = giftRepository.save(Gift.builder()
+                    .giftName("선물" + i).giftImageUrl("https://img/" + i + ".jpg")
+                    .description("설명").isProbabilityPublic(true).build());
+            capsuleRepository.save(Capsule.builder()
+                    .capsuleEvent(capsuleEvent).gift(gift).weight(50).build());
+        }
+        em.flush();
+        em.clear();
+
+        // 2번 뽑기 (정상)
+        mockMvc.perform(post("/events/EDGE_CAP1/capsules/draw"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/events/EDGE_CAP1/capsules/draw"))
+                .andExpect(status().isOk());
+
+        // 3번째 뽑기 → 캡슐 소진
+        mockMvc.perform(post("/events/EDGE_CAP1/capsules/draw"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CAPSULE_ALL_DRAWN"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 2. 뽑지 않은 캡슐 select → CAPSULE_DRAW_NOT_FOUND
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("캡슐: 뽑지 않은 capsuleId로 select → CAPSULE_DRAW_NOT_FOUND")
+    void capsule_selectNotDrawn() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_CAP2").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        CapsuleEvent capsuleEvent = capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(3).build());
+
+        Gift gift = giftRepository.save(Gift.builder()
+                .giftName("선물").giftImageUrl("https://img/gift.jpg")
+                .description("설명").isProbabilityPublic(true).build());
+        Capsule capsule = capsuleRepository.save(Capsule.builder()
+                .capsuleEvent(capsuleEvent).gift(gift).weight(100).build());
+        em.flush();
+        em.clear();
+
+        // 뽑지 않고 바로 select 시도
+        mockMvc.perform(post("/events/EDGE_CAP2/capsules/select")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"capsuleId\":" + capsule.getCapsuleId() + "}"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CAPSULE_DRAW_NOT_FOUND"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 3. 잘못된 quizId 제출 → QUIZ_QUESTION_NOT_FOUND
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: 이벤트에 속하지 않는 quizId로 answer 제출 → QUIZ_QUESTION_NOT_FOUND")
+    void quiz_invalidQuizId() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_QZ1").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("문제").quizType(QuizType.OX)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
+        em.flush();
+        em.clear();
+
+        // 존재하지 않는 quizId = 99999
+        mockMvc.perform(post("/events/EDGE_QZ1/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":99999,\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("QUIZ_QUESTION_NOT_FOUND"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 4. 만료/삭제된 이벤트 접근
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("이벤트: EXPIRED 상태 이벤트 조회 → EVENT_EXPIRED")
+    void event_expired() throws Exception {
+        birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_EXP").status(EventStatus.EXPIRED)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().minusDays(1)).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(get("/events/EDGE_EXP"))
+                .andDo(print())
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.code").value("EVENT_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("이벤트: DELETED 상태 이벤트 조회 → EVENT_DELETED")
+    void event_deleted() throws Exception {
+        birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_DEL").status(EventStatus.DELETED)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(get("/events/EDGE_DEL"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("EVENT_DELETED"));
+    }
+
+    @Test
+    @DisplayName("이벤트: EXPIRED 이벤트에 캡슐 뽑기 시도 → EVENT_EXPIRED")
+    void event_expired_capsuleDraw() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_EXP2").status(EventStatus.EXPIRED)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().minusDays(1)).build());
+
+        CapsuleEvent capsuleEvent = capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(3).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(post("/events/EDGE_EXP2/capsules/draw"))
+                .andDo(print())
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.code").value("EVENT_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("이벤트: EXPIRED 이벤트에 퀴즈 답안 제출 → EVENT_EXPIRED")
+    void event_expired_quizAnswer() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_EXP3").status(EventStatus.EXPIRED)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().minusDays(1)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(post("/events/EDGE_EXP3/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":1,\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.code").value("EVENT_EXPIRED"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 5. 퀴즈 리셋 후 재시도
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: 리셋 후 같은 문제 다시 풀기 가능")
+    void quiz_resetAndRetry() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_RST1").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Gift gift = giftRepository.save(Gift.builder()
+                .giftName("선물").giftImageUrl("https://img/gift.jpg")
+                .description("축하!").isProbabilityPublic(true).build());
+        quizRewardRuleRepository.save(QuizRewardRule.builder()
+                .quizEvent(quizEvent).minCorrect(1).gift(gift).build());
+        quizRewardRuleRepository.save(QuizRewardRule.builder()
+                .quizEvent(quizEvent).minCorrect(0).gift(gift).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("X").isCorrect(false).build());
+        em.flush();
+        em.clear();
+
+        // 1차: 오답 3번으로 실패
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/answer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2));
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/answer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(1));
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/answer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"))
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0));
+
+        // result 호출
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/result")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"correctCount\":0}"))
+                .andExpect(jsonPath("$.data.correctCount").value(0))
+                .andExpect(jsonPath("$.data.success").value(false));
+
+        // 리셋
+        mockMvc.perform(delete("/events/EDGE_RST1/progress"))
+                .andExpect(status().isOk());
+
+        // 리셋 후 초기 상태 확인
+        mockMvc.perform(get("/events/EDGE_RST1"))
+                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(0))
+                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").isEmpty());
+
+        // 2차: 같은 문제 다시 풀기 → 정답
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
+
+        // 2차 result → 성공
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/result")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"correctCount\":1}"))
+                .andExpect(jsonPath("$.data.correctCount").value(1))
+                .andExpect(jsonPath("$.data.success").value(true));
+    }
+
+    // ══════════════════════════════════════════════
+    // 6. 공백/빈 문자열 답안
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: 공백만 있는 답안 제출 → @NotBlank VALIDATION_ERROR")
+    void quiz_whitespaceAnswer() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_WS").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("문제").quizType(QuizType.SUBJECTIVE)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("정답").isCorrect(true).build());
+        em.flush();
+        em.clear();
+
+        // 공백만 입력 → @NotBlank에 의해 validation 실패
+        mockMvc.perform(post("/events/EDGE_WS/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"   \"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 7. OX 대소문자 무시
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: OX 소문자 'o' 입력도 정답 처리")
+    void quiz_ox_caseInsensitive() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_OX").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("고양이 키운다").quizType(QuizType.OX)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("X").isCorrect(false).build());
+        em.flush();
+        em.clear();
+
+        // 소문자 'o'로 제출
+        mockMvc.perform(post("/events/EDGE_OX/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"o\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true));
+    }
+
+    @Test
+    @DisplayName("퀴즈: OX 소문자 'x'도 오답으로 인식 (정답이 O일 때)")
+    void quiz_ox_lowercase_x() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_OX2").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("고양이 키운다").quizType(QuizType.OX)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("X").isCorrect(false).build());
+        em.flush();
+        em.clear();
+
+        // 소문자 'x'로 제출 → 오답
+        mockMvc.perform(post("/events/EDGE_OX2/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"x\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false));
+    }
+
+    // ══════════════════════════════════════════════
+    // 8. 요청 유효성 검증 (@Valid)
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: quizId 누락 시 에러 응답")
+    void quiz_missingQuizId() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_VAL1").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+        em.flush();
+        em.clear();
+
+        // quizId 누락 → @NotNull VALIDATION_ERROR
+        mockMvc.perform(post("/events/EDGE_VAL1/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("퀴즈: selectedAnswer 빈 문자열 → @NotBlank VALIDATION_ERROR")
+    void quiz_emptySelectedAnswer() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_VAL2").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("문제").quizType(QuizType.OX)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(post("/events/EDGE_VAL2/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"\"}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("캡슐: capsuleId null로 select → @NotNull VALIDATION_ERROR")
+    void capsule_nullCapsuleId() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_VAL3").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(3).build());
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(post("/events/EDGE_VAL3/capsules/select")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"capsuleId\":null}"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 9. 캡슐 리셋 후 재뽑기 전체 플로우
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("캡슐: 리셋 후 다시 전체 횟수만큼 뽑기 가능")
+    void capsule_resetAndRedraw() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_RST2").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        CapsuleEvent capsuleEvent = capsuleEventRepository.save(CapsuleEvent.builder()
+                .birthdayEvent(event).maxDrawCount(2).build());
+
+        for (int i = 0; i < 3; i++) {
+            Gift gift = giftRepository.save(Gift.builder()
+                    .giftName("선물" + i).giftImageUrl("https://img/" + i + ".jpg")
+                    .description("설명").isProbabilityPublic(true).build());
+            capsuleRepository.save(Capsule.builder()
+                    .capsuleEvent(capsuleEvent).gift(gift).weight(30).build());
+        }
+        em.flush();
+        em.clear();
+
+        // 2번 뽑기
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andExpect(status().isOk());
+
+        // 횟수 초과
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CAPSULE_DRAW_LIMIT_EXCEEDED"));
+
+        // 리셋
+        mockMvc.perform(delete("/events/EDGE_RST2/progress"))
+                .andExpect(status().isOk());
+
+        // 리셋 후 초기 상태 확인
+        mockMvc.perform(get("/events/EDGE_RST2"))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(2))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(0))
+                .andExpect(jsonPath("$.data.content.gacha.selected").value(false));
+
+        // 다시 2번 뽑기 가능
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // 다시 횟수 초과
+        mockMvc.perform(post("/events/EDGE_RST2/capsules/draw"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CAPSULE_DRAW_LIMIT_EXCEEDED"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 10. 존재하지 않는 eventUrl 접근
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("이벤트: 존재하지 않는 eventUrl 조회 → EVENT_NOT_FOUND")
+    void event_notFound() throws Exception {
+        mockMvc.perform(get("/events/NOTEXIST"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("EVENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("이벤트: 존재하지 않는 eventUrl로 캡슐 뽑기 → EVENT_NOT_FOUND")
+    void event_notFound_capsuleDraw() throws Exception {
+        mockMvc.perform(post("/events/NOTEXIST/capsules/draw"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("EVENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("이벤트: 존재하지 않는 eventUrl로 퀴즈 답안 제출 → EVENT_NOT_FOUND")
+    void event_notFound_quizAnswer() throws Exception {
+        mockMvc.perform(post("/events/NOTEXIST/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":1,\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("EVENT_NOT_FOUND"));
+    }
+
+    // ══════════════════════════════════════════════
+    // 11. 객관식 대소문자 무시
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: 객관식 대소문자 무시 비교 (영어 답안)")
+    void quiz_objective_caseInsensitive() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_CASE").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("좋아하는 브랜드?").quizType(QuizType.OBJECTIVE)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("Apple").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("Samsung").isCorrect(false).build());
+        em.flush();
+        em.clear();
+
+        // 소문자 "apple"로 제출 → 정답
+        mockMvc.perform(post("/events/EDGE_CASE/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"apple\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true));
+    }
+
+    // ══════════════════════════════════════════════
+    // 12. 답안 앞뒤 공백 trim 처리
+    // ══════════════════════════════════════════════
+
+    @Test
+    @DisplayName("퀴즈: 답안 앞뒤 공백 trim 후 비교")
+    void quiz_trimAnswer() throws Exception {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("EDGE_TRIM").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("처음 만난 장소?").quizType(QuizType.SUBJECTIVE)
+                .playLimit(3).sortOrder(1).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("스타벅스").isCorrect(true).build());
+        em.flush();
+        em.clear();
+
+        // 앞뒤 공백 포함 "  스타벅스  " → 정답
+        mockMvc.perform(post("/events/EDGE_TRIM/quiz/answer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"  스타벅스  \"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true));
+    }
+}

--- a/src/test/java/com/gifo/backend/integration/QuizApiTest.java
+++ b/src/test/java/com/gifo/backend/integration/QuizApiTest.java
@@ -66,6 +66,7 @@ class QuizApiTest {
         quizRewardRuleRepository.save(QuizRewardRule.builder()
                 .quizEvent(quizEvent).minCorrect(0).gift(failGift).build());
 
+        // 객관식: 정답 "치킨"
         Quiz q1 = quizRepository.save(Quiz.builder()
                 .quizEvent(quizEvent).question("좋아하는 음식은?")
                 .quizType(QuizType.OBJECTIVE).playLimit(3).sortOrder(1).build());
@@ -73,6 +74,7 @@ class QuizApiTest {
         quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("치킨").isCorrect(true).build());
         quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("피자").isCorrect(false).build());
 
+        // OX: 정답 "O"
         Quiz q2 = quizRepository.save(Quiz.builder()
                 .quizEvent(quizEvent).question("고양이를 키운다")
                 .quizType(QuizType.OX).playLimit(2).sortOrder(2).build());
@@ -80,113 +82,146 @@ class QuizApiTest {
         quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("O").isCorrect(true).build());
         quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("X").isCorrect(false).build());
 
+        // 주관식: 허용 답안 "스타벅스", "스벅"
         Quiz q3 = quizRepository.save(Quiz.builder()
                 .quizEvent(quizEvent).question("처음 만난 장소?")
                 .quizType(QuizType.SUBJECTIVE).playLimit(3).sortOrder(3).build());
         quiz3Id = q3.getQuizId();
         quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("스타벅스").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("스벅").isCorrect(true).build());
 
         em.flush();
         em.clear();
     }
 
     @Test
-    @DisplayName("1. GET /events/{eventUrl} - 퀴즈 이벤트 초기 조회")
+    @DisplayName("1. GET /events/{eventUrl} - 퀴즈 이벤트 초기 조회 (answer 필드 없음)")
     void getEvent_quiz_initial() throws Exception {
         mockMvc.perform(get("/events/{eventUrl}", eventUrl))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.gacha").isEmpty())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))
                 .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").isEmpty())
-                .andExpect(jsonPath("$.data.content.quiz.successReward.requiredCount").value(2))
-                .andExpect(jsonPath("$.data.content.quiz.successReward.itemName").value("에어팟 프로"))
-                .andExpect(jsonPath("$.data.content.quiz.failReward.itemName").value("양말 세트"))
                 .andExpect(jsonPath("$.data.content.quiz.list.length()").value(3))
+                .andExpect(jsonPath("$.data.content.quiz.list[0].options.length()").value(2))
+                .andExpect(jsonPath("$.data.content.quiz.list[0].answer").doesNotExist())
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(0));
     }
 
     @Test
-    @DisplayName("2. POST /quiz/answer - 정답 저장")
-    void saveAnswer_correct() throws Exception {
+    @DisplayName("2. POST /quiz/answer - 정답 제출 → correct=true, remainingAttempts=0")
+    void submitAnswer_correct() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"))
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.quizId").value(quiz1Id))
                 .andExpect(jsonPath("$.data.correct").value(true))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0))
                 .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
     }
 
     @Test
-    @DisplayName("3. POST /quiz/answer - 오답 저장")
-    void saveAnswer_incorrect() throws Exception {
+    @DisplayName("3. POST /quiz/answer - 오답 제출 → correct=false, remainingAttempts 차감")
+    void submitAnswer_incorrect_hasRetry() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"quizId\":" + quiz1Id + ",\"correct\":false,\"remainingAttempts\":0}"))
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(0));
+    }
+
+    @Test
+    @DisplayName("4. 오답 3번으로 playLimit 소진 → correct=false, remainingAttempts=0, 다음 문제로")
+    void submitAnswer_exhaustAttempts() throws Exception {
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2));
+
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(1));
+
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0))
                 .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
     }
 
     @Test
-    @DisplayName("4. 이미 답변한 문제 다시 저장 시 에러")
-    void saveAnswer_duplicate() throws Exception {
+    @DisplayName("5. 이미 답변 완료된 문제에 다시 제출 → QUIZ_ALREADY_ANSWERED")
+    void submitAnswer_duplicate() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
 
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"))
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("QUIZ_ALREADY_ANSWERED"));
     }
 
     @Test
-    @DisplayName("5. 전체 플로우: 3문제 풀기 → result → 성공 보상 (2개 이상 정답)")
+    @DisplayName("6. 전체 플로우: 3문제 정답 → result → 성공 보상")
     void fullFlow_success() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz2Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"O\"}"));
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz3Id + ",\"correct\":false,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"스벅\"}"));
 
         mockMvc.perform(get("/events/{eventUrl}", eventUrl))
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(3))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(3))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].correct").value(true))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory[2].correct").value(false));
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(3));
 
         mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":2}"))
+                        .content("{\"correctCount\":3}"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.correctCount").value(2))
+                .andExpect(jsonPath("$.data.correctCount").value(3))
                 .andExpect(jsonPath("$.data.success").value(true));
     }
 
     @Test
-    @DisplayName("6. 전체 플로우: 3문제 풀기 → result → 실패 보상 (1개 정답)")
+    @DisplayName("7. 전체 플로우: 1개만 정답 → result → 실패 보상")
     void fullFlow_fail() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
+        // playLimit 소진 (2번 오답)
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz2Id + ",\"correct\":false,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"X\"}"));
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz3Id + ",\"correct\":false,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"X\"}"));
+        // playLimit 소진 (3번 오답)
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"맥도날드\"}"));
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"투썸\"}"));
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"이디야\"}"));
 
         mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -197,16 +232,20 @@ class QuizApiTest {
     }
 
     @Test
-    @DisplayName("7. 답변 완료 후 remainingAttempts null 초기화 확인")
-    void remainingAttempts_clearedAfterAnswer() throws Exception {
+    @DisplayName("8. 주관식 대소문자 무시 비교")
+    void submitAnswer_subjective_caseInsensitive() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":2}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"O\"}"));
 
-        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"스타벅스\"}"))
                 .andDo(print())
-                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(1))
-                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").isEmpty());
+                .andExpect(jsonPath("$.data.correct").value(true));
     }
 
     @Test
@@ -214,7 +253,7 @@ class QuizApiTest {
     void result_beforeAllAnswered() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
 
         mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -225,14 +264,11 @@ class QuizApiTest {
     }
 
     @Test
-    @DisplayName("8. DELETE /progress - 퀴즈 리셋 후 초기화 확인")
+    @DisplayName("10. DELETE /progress - 퀴즈 리셋 후 초기화 확인")
     void resetProgress_quiz() throws Exception {
         mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
-        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz2Id + ",\"correct\":false,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
 
         mockMvc.perform(delete("/events/{eventUrl}/progress", eventUrl))
                 .andExpect(status().isOk());
@@ -241,5 +277,18 @@ class QuizApiTest {
                 .andDo(print())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("11. 오답 후 재접속 → remainingAttempts 복원")
+    void remainingAttempts_restoredOnResume() throws Exception {
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"));
+
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andDo(print())
+                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))
+                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").value(2));
     }
 }

--- a/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
@@ -1,0 +1,200 @@
+package com.gifo.backend.integration;
+
+import com.gifo.backend.entity.event.BirthdayEvent;
+import com.gifo.backend.entity.event.EventStatus;
+import com.gifo.backend.entity.gift.Gift;
+import com.gifo.backend.entity.quiz.*;
+import com.gifo.backend.repository.event.BirthdayEventRepository;
+import com.gifo.backend.repository.gift.GiftRepository;
+import com.gifo.backend.repository.quiz.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import jakarta.persistence.EntityManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 퀴즈 전체 플로우 시나리오 테스트
+ *
+ * 3문제, 각 3번씩 기회 (playLimit=3)
+ * Q1(객관식): 3번 모두 오답 → 시도 소진, correct=false
+ * Q2(OX):    1번 오답 → 2번째에 정답
+ * Q3(주관식): 첫 시도에 정답
+ * → result: correctCount=2, success=true (minCorrect=2)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class QuizFullFlowTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired EntityManager em;
+    @Autowired BirthdayEventRepository birthdayEventRepository;
+    @Autowired QuizEventRepository quizEventRepository;
+    @Autowired QuizRepository quizRepository;
+    @Autowired QuizChoiceRepository quizChoiceRepository;
+    @Autowired QuizRewardRuleRepository quizRewardRuleRepository;
+    @Autowired GiftRepository giftRepository;
+
+    private String eventUrl;
+    private Long quiz1Id;
+    private Long quiz2Id;
+    private Long quiz3Id;
+
+    @BeforeEach
+    void setUp() {
+        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
+                .eventUrl("FLOW1234").status(EventStatus.ACTIVE)
+                .receiverName("김철수").senderName("박영희").title("생일 축하해")
+                .expiredAt(LocalDateTime.now().plusDays(7)).build());
+        eventUrl = event.getEventUrl();
+
+        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
+                .birthdayEvent(event).totalAttempt(0).build());
+
+        Gift successGift = giftRepository.save(Gift.builder()
+                .giftName("에어팟 프로").giftImageUrl("https://img/airpods.jpg")
+                .description("축하해요!").isProbabilityPublic(true).build());
+        Gift failGift = giftRepository.save(Gift.builder()
+                .giftName("양말 세트").giftImageUrl("https://img/socks.jpg")
+                .description("다음에!").isProbabilityPublic(true).build());
+
+        // 2개 이상 정답이면 성공
+        quizRewardRuleRepository.save(QuizRewardRule.builder()
+                .quizEvent(quizEvent).minCorrect(2).gift(successGift).build());
+        quizRewardRuleRepository.save(QuizRewardRule.builder()
+                .quizEvent(quizEvent).minCorrect(0).gift(failGift).build());
+
+        // Q1 객관식 (정답: "치킨"), playLimit=3
+        Quiz q1 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("좋아하는 음식은?")
+                .quizType(QuizType.OBJECTIVE).playLimit(3).sortOrder(1).build());
+        quiz1Id = q1.getQuizId();
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("치킨").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("피자").isCorrect(false).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("햄버거").isCorrect(false).build());
+
+        // Q2 OX (정답: "O"), playLimit=3
+        Quiz q2 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("고양이를 키운다")
+                .quizType(QuizType.OX).playLimit(3).sortOrder(2).build());
+        quiz2Id = q2.getQuizId();
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("O").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("X").isCorrect(false).build());
+
+        // Q3 주관식 (허용 답안: "스타벅스", "스벅"), playLimit=3
+        Quiz q3 = quizRepository.save(Quiz.builder()
+                .quizEvent(quizEvent).question("처음 만난 장소?")
+                .quizType(QuizType.SUBJECTIVE).playLimit(3).sortOrder(3).build());
+        quiz3Id = q3.getQuizId();
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("스타벅스").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("스벅").isCorrect(true).build());
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("전체 시나리오: Q1 3번 오답 → Q2 1번 오답+정답 → Q3 첫 시도 정답 → result 성공")
+    void fullFlow_mixedResults() throws Exception {
+        // ── Q1: 객관식, 3번 모두 오답 (시도 소진) ──
+
+        // 1번째 시도: 오답 → remainingAttempts=2
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(0));
+
+        // 2번째 시도: 오답 → remainingAttempts=1
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"햄버거\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(1))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(0));
+
+        // 3번째 시도: 오답 → remainingAttempts=0, 시도 소진으로 다음 문제
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"피자\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
+
+        // Q1 다시 제출하면 QUIZ_ALREADY_ANSWERED
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("QUIZ_ALREADY_ANSWERED"));
+
+        // ── Q2: OX, 1번 오답 후 2번째에 정답 ──
+
+        // 1번째 시도: 오답 → remainingAttempts=2
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"X\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
+
+        // 2번째 시도: 정답 → remainingAttempts=0, 다음 문제
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz2Id + ",\"selectedAnswer\":\"O\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(2));
+
+        // ── Q3: 주관식, 첫 시도에 정답 ──
+
+        mockMvc.perform(post("/events/{eventUrl}/quiz/answer", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"스벅\"}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(0))
+                .andExpect(jsonPath("$.data.currentQuizIndex").value(3));
+
+        // ── GET 재접속: answerHistory 3개, currentQuizIndex=3 ──
+
+        mockMvc.perform(get("/events/{eventUrl}", eventUrl))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(3))
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(3))
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].correct").value(false))
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory[1].correct").value(true))
+                .andExpect(jsonPath("$.data.content.quiz.answerHistory[2].correct").value(true));
+
+        // ── result: correctCount=2 (Q2+Q3), success=true (minCorrect=2) ──
+
+        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"correctCount\":2}"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correctCount").value(2))
+                .andExpect(jsonPath("$.data.success").value(true));
+    }
+}

--- a/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
@@ -183,15 +183,19 @@ class QuizFullFlowTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(3))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(3))
+                .andExpect(jsonPath("$.data.content.quiz.list[0].answer").doesNotExist())
+                .andExpect(jsonPath("$.data.content.quiz.list[1].answer").doesNotExist())
+                .andExpect(jsonPath("$.data.content.quiz.list[2].answer").doesNotExist())
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].correct").value(false))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory[1].correct").value(true))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory[2].correct").value(true));
 
         // ── result: correctCount=2 (Q2+Q3), success=true (minCorrect=2) ──
 
+        // 일부러 틀린 correctCount(0)를 보내서 서버가 DB 기준으로 재계산하는지 검증
         mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":2}"))
+                        .content("{\"correctCount\":0}"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.correctCount").value(2))

--- a/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
@@ -73,8 +73,10 @@ class ResumeFlowTest {
         em.flush();
         em.clear();
 
-        mockMvc.perform(post("/events/RESUME01/capsules/draw"));
-        mockMvc.perform(post("/events/RESUME01/capsules/draw"));
+        mockMvc.perform(post("/events/RESUME01/capsules/draw"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/events/RESUME01/capsules/draw"))
+                .andExpect(status().isOk());
 
         mockMvc.perform(get("/events/RESUME01"))
                 .andDo(print())
@@ -201,7 +203,9 @@ class ResumeFlowTest {
 
         mockMvc.perform(post("/events/RESUME04/quiz/answer")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"));
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true));
 
         mockMvc.perform(get("/events/RESUME04"))
                 .andDo(print())
@@ -241,7 +245,10 @@ class ResumeFlowTest {
         // 1번 오답 → remainingAttempts=2
         mockMvc.perform(post("/events/RESUME06/quiz/answer")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"));
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(false))
+                .andExpect(jsonPath("$.data.remainingAttempts").value(2));
 
         mockMvc.perform(get("/events/RESUME06"))
                 .andDo(print())

--- a/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
@@ -286,7 +286,9 @@ class ResumeFlowTest {
 
         mockMvc.perform(post("/events/RESUME07/quiz/answer")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"));
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.correct").value(true));
 
         mockMvc.perform(delete("/events/RESUME07/progress"));
 

--- a/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
@@ -30,8 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * 이어하기(재접속) 플로우 테스트
- * 중간에 나갔다가 다시 GET /events/{eventUrl}을 호출했을 때
- * 히스토리가 정상적으로 복원되는지 검증
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -39,35 +37,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class ResumeFlowTest {
 
-    @Autowired
-    MockMvc mockMvc;
-    @Autowired
-    EntityManager em;
+    @Autowired MockMvc mockMvc;
+    @Autowired EntityManager em;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    @Autowired
-    BirthdayEventRepository birthdayEventRepository;
-    @Autowired
-    CapsuleEventRepository capsuleEventRepository;
-    @Autowired
-    CapsuleRepository capsuleRepository;
-    @Autowired
-    GiftRepository giftRepository;
-    @Autowired
-    QuizEventRepository quizEventRepository;
-    @Autowired
-    QuizRepository quizRepository;
-    @Autowired
-    QuizChoiceRepository quizChoiceRepository;
-    @Autowired
-    QuizRewardRuleRepository quizRewardRuleRepository;
+    @Autowired BirthdayEventRepository birthdayEventRepository;
+    @Autowired CapsuleEventRepository capsuleEventRepository;
+    @Autowired CapsuleRepository capsuleRepository;
+    @Autowired GiftRepository giftRepository;
+    @Autowired QuizEventRepository quizEventRepository;
+    @Autowired QuizRepository quizRepository;
+    @Autowired QuizChoiceRepository quizChoiceRepository;
+    @Autowired QuizRewardRuleRepository quizRewardRuleRepository;
 
     // ── 캡슐 이어하기 ──────────────────────────────
 
     @Test
     @DisplayName("캡슐: 2번 뽑고 재접속 → drawHistory 2건 + remainingDrawCount 1 복원")
     void capsule_resume_drawHistory() throws Exception {
-        // 캡슐 이벤트 세팅
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
                 .eventUrl("RESUME01").status(EventStatus.ACTIVE)
                 .receiverName("김철수").senderName("박영희").title("축하해")
@@ -86,29 +73,24 @@ class ResumeFlowTest {
         em.flush();
         em.clear();
 
-        // 2번 뽑기
         mockMvc.perform(post("/events/RESUME01/capsules/draw"));
         mockMvc.perform(post("/events/RESUME01/capsules/draw"));
 
-        // "재접속" = GET /events/{eventUrl}
         mockMvc.perform(get("/events/RESUME01"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.gacha.playCount").value(3))
                 .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(1))
                 .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(2))
-                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].capsuleId").isNumber())
-                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].giftName").isString())
                 .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].selected").value(false))
-                .andExpect(jsonPath("$.data.content.gacha.drawHistory[1].capsuleId").isNumber())
                 .andExpect(jsonPath("$.data.content.gacha.list.length()").value(1));
     }
 
     @Test
-    @DisplayName("캡슐: 뽑기 후 선택 → 재접속 시 selected=true 복원")
-    void capsule_resume_selected() throws Exception {
+    @DisplayName("캡슐: 선택 후에도 추가 뽑기 가능")
+    void capsule_drawAfterSelect() throws Exception {
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
-                .eventUrl("RESUME02").status(EventStatus.ACTIVE)
+                .eventUrl("RESUME09").status(EventStatus.ACTIVE)
                 .receiverName("김철수").senderName("박영희").title("축하해")
                 .expiredAt(LocalDateTime.now().plusDays(7)).build());
 
@@ -125,24 +107,27 @@ class ResumeFlowTest {
         em.flush();
         em.clear();
 
-        // 1번 뽑기 + 선택
-        String drawResult = mockMvc.perform(post("/events/RESUME02/capsules/draw"))
+        String drawResult = mockMvc.perform(post("/events/RESUME09/capsules/draw"))
                 .andReturn().getResponse().getContentAsString();
         Long capsuleId = objectMapper.readTree(drawResult).path("data").path("capsuleId").asLong();
 
-        mockMvc.perform(post("/events/RESUME02/capsules/select")
+        mockMvc.perform(post("/events/RESUME09/capsules/select")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"capsuleId\":" + capsuleId + "}"));
 
-        // "재접속"
-        mockMvc.perform(get("/events/RESUME02"))
+        // 선택 후에도 추가 뽑기 가능
+        mockMvc.perform(post("/events/RESUME09/capsules/draw"))
                 .andDo(print())
-                .andExpect(jsonPath("$.data.content.gacha.selected").value(true))
-                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].selected").value(true));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.capsuleId").isNumber());
+
+        mockMvc.perform(get("/events/RESUME09"))
+                .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(1))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(2));
     }
 
     @Test
-    @DisplayName("캡슐: 리셋 후 재접속 → 히스토리 초기화 + 전체 횟수 복원")
+    @DisplayName("캡슐: 리셋 후 재접속 → 히스토리 초기화")
     void capsule_resume_afterReset() throws Exception {
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
                 .eventUrl("RESUME03").status(EventStatus.ACTIVE)
@@ -162,15 +147,12 @@ class ResumeFlowTest {
         em.flush();
         em.clear();
 
-        // 3번 다 뽑기
         mockMvc.perform(post("/events/RESUME03/capsules/draw"));
         mockMvc.perform(post("/events/RESUME03/capsules/draw"));
         mockMvc.perform(post("/events/RESUME03/capsules/draw"));
 
-        // 리셋
         mockMvc.perform(delete("/events/RESUME03/progress"));
 
-        // "재접속"
         mockMvc.perform(get("/events/RESUME03"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.content.gacha.remainingDrawCount").value(3))
@@ -181,7 +163,7 @@ class ResumeFlowTest {
     // ── 퀴즈 이어하기 ──────────────────────────────
 
     @Test
-    @DisplayName("퀴즈: 1문제 풀고 재접속 → answerHistory 1건 + currentQuizIndex=1 복원")
+    @DisplayName("퀴즈: 1문제 정답 후 재접속 → answerHistory 1건 + currentQuizIndex=1")
     void quiz_resume_answerHistory() throws Exception {
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
                 .eventUrl("RESUME04").status(EventStatus.ACTIVE)
@@ -191,17 +173,13 @@ class ResumeFlowTest {
         QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
                 .birthdayEvent(event).totalAttempt(0).build());
 
-        Gift successGift = giftRepository.save(Gift.builder()
-                .giftName("에어팟").giftImageUrl("https://img/airpods.jpg")
+        Gift gift = giftRepository.save(Gift.builder()
+                .giftName("선물").giftImageUrl("https://img/gift.jpg")
                 .description("축하!").isProbabilityPublic(true).build());
-        Gift failGift = giftRepository.save(Gift.builder()
-                .giftName("양말").giftImageUrl("https://img/socks.jpg")
-                .description("다음에!").isProbabilityPublic(true).build());
-
         quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(2).gift(successGift).build());
+                .quizEvent(quizEvent).minCorrect(1).gift(gift).build());
         quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(0).gift(failGift).build());
+                .quizEvent(quizEvent).minCorrect(0).gift(gift).build());
 
         Quiz q1 = quizRepository.save(Quiz.builder()
                 .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
@@ -215,89 +193,22 @@ class ResumeFlowTest {
         quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("O").isCorrect(true).build());
         quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("X").isCorrect(false).build());
 
-        Quiz q3 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제3").quizType(QuizType.OX)
-                .playLimit(2).sortOrder(3).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("O").isCorrect(true).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("X").isCorrect(false).build());
-
         em.flush();
         em.clear();
 
-        Long quiz1Id = q1.getQuizId();
-        Long quiz2Id = q2.getQuizId();
-
-        // 문제 1: 정답
         mockMvc.perform(post("/events/RESUME04/quiz/answer")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + quiz1Id + ",\"correct\":true,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"));
 
-        // "재접속" - 1문제 풀었으니 currentQuizIndex=1, answerHistory 1건
         mockMvc.perform(get("/events/RESUME04"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(1))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(1))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].quizId").value(quiz1Id))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].correct").value(true));
     }
 
     @Test
-    @DisplayName("퀴즈: 2문제 풀고 재접속 → currentQuizIndex=2, answerHistory에 정답/오답 섞여있음")
-    void quiz_resume_mixedAnswers() throws Exception {
-        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
-                .eventUrl("RESUME05").status(EventStatus.ACTIVE)
-                .receiverName("김철수").senderName("박영희").title("축하해")
-                .expiredAt(LocalDateTime.now().plusDays(7)).build());
-
-        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
-                .birthdayEvent(event).totalAttempt(0).build());
-
-        Gift gift = giftRepository.save(Gift.builder()
-                .giftName("선물").giftImageUrl("https://img/gift.jpg")
-                .description("축하!").isProbabilityPublic(true).build());
-        quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(2).gift(gift).build());
-        quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(0).gift(gift).build());
-
-        Quiz q1 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
-                .playLimit(2).sortOrder(1).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
-
-        Quiz q2 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제2").quizType(QuizType.OX)
-                .playLimit(2).sortOrder(2).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("O").isCorrect(true).build());
-
-        Quiz q3 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제3").quizType(QuizType.OX)
-                .playLimit(2).sortOrder(3).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q3).choiceText("O").isCorrect(true).build());
-
-        em.flush();
-        em.clear();
-
-        // 문제 1: 정답, 문제 2: 오답
-        mockMvc.perform(post("/events/RESUME05/quiz/answer")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"correct\":true,\"remainingAttempts\":0}"));
-        mockMvc.perform(post("/events/RESUME05/quiz/answer")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q2.getQuizId() + ",\"correct\":false,\"remainingAttempts\":0}"));
-
-        // "재접속"
-        mockMvc.perform(get("/events/RESUME05"))
-                .andDo(print())
-                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(2))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(2))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory[0].correct").value(true))
-                .andExpect(jsonPath("$.data.content.quiz.answerHistory[1].correct").value(false))
-                .andExpect(jsonPath("$.data.content.quiz.list.length()").value(3));
-    }
-
-    @Test
-    @DisplayName("퀴즈: 문제 풀다가 중간에 나감 → remainingAttempts 복원 (DB 직접 세팅)")
+    @DisplayName("퀴즈: 오답 시도 중 재접속 → remainingAttempts 복원")
     void quiz_resume_remainingAttempts() throws Exception {
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
                 .eventUrl("RESUME06").status(EventStatus.ACTIVE)
@@ -319,60 +230,24 @@ class ResumeFlowTest {
                 .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
                 .playLimit(3).sortOrder(1).build());
         quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
-
-        // 문제를 풀다가 중간에 나간 상태를 시뮬레이션: DB에 remainingAttempts만 세팅
-        quizEvent.setCurrentQuizRemainingAttempts(1);
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("X").isCorrect(false).build());
 
         em.flush();
         em.clear();
 
-        // "재접속" - 아직 문제를 완료하지 않았으므로 remainingAttempts=1 복원
+        // 1번 오답 → remainingAttempts=2
+        mockMvc.perform(post("/events/RESUME06/quiz/answer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"X\"}"));
+
         mockMvc.perform(get("/events/RESUME06"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))
-                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").value(1));
+                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").value(2));
     }
 
     @Test
-    @DisplayName("퀴즈: saveAnswer 호출 후 → remainingAttempts null로 초기화 확인")
-    void quiz_resume_remainingAttempts_afterAnswer() throws Exception {
-        BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
-                .eventUrl("RESUME08").status(EventStatus.ACTIVE)
-                .receiverName("김철수").senderName("박영희").title("축하해")
-                .expiredAt(LocalDateTime.now().plusDays(7)).build());
-
-        QuizEvent quizEvent = quizEventRepository.save(QuizEvent.builder()
-                .birthdayEvent(event).totalAttempt(0).build());
-
-        Gift gift = giftRepository.save(Gift.builder()
-                .giftName("선물").giftImageUrl("https://img/gift.jpg")
-                .description("축하!").isProbabilityPublic(true).build());
-        quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(1).gift(gift).build());
-        quizRewardRuleRepository.save(QuizRewardRule.builder()
-                .quizEvent(quizEvent).minCorrect(0).gift(gift).build());
-
-        Quiz q1 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
-                .playLimit(3).sortOrder(1).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
-
-        em.flush();
-        em.clear();
-
-        // saveAnswer 호출 → 문제 완료 → remainingAttempts는 null로 초기화
-        mockMvc.perform(post("/events/RESUME08/quiz/answer")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"correct\":false,\"remainingAttempts\":1}"));
-
-        mockMvc.perform(get("/events/RESUME08"))
-                .andDo(print())
-                .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(1))
-                .andExpect(jsonPath("$.data.content.quiz.remainingAttempts").isEmpty());
-    }
-
-    @Test
-    @DisplayName("퀴즈: 리셋 후 재접속 → answerHistory 초기화 + currentQuizIndex=0")
+    @DisplayName("퀴즈: 리셋 후 재접속 → 초기화")
     void quiz_resume_afterReset() throws Exception {
         BirthdayEvent event = birthdayEventRepository.save(BirthdayEvent.builder()
                 .eventUrl("RESUME07").status(EventStatus.ACTIVE)
@@ -394,27 +269,17 @@ class ResumeFlowTest {
                 .quizEvent(quizEvent).question("문제1").quizType(QuizType.OX)
                 .playLimit(2).sortOrder(1).build());
         quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("O").isCorrect(true).build());
-
-        Quiz q2 = quizRepository.save(Quiz.builder()
-                .quizEvent(quizEvent).question("문제2").quizType(QuizType.OX)
-                .playLimit(2).sortOrder(2).build());
-        quizChoiceRepository.save(QuizChoice.builder().quiz(q2).choiceText("O").isCorrect(true).build());
+        quizChoiceRepository.save(QuizChoice.builder().quiz(q1).choiceText("X").isCorrect(false).build());
 
         em.flush();
         em.clear();
 
-        // 2문제 다 풀기
         mockMvc.perform(post("/events/RESUME07/quiz/answer")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q1.getQuizId() + ",\"correct\":true,\"remainingAttempts\":0}"));
-        mockMvc.perform(post("/events/RESUME07/quiz/answer")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"quizId\":" + q2.getQuizId() + ",\"correct\":false,\"remainingAttempts\":0}"));
+                .content("{\"quizId\":" + q1.getQuizId() + ",\"selectedAnswer\":\"O\"}"));
 
-        // 리셋
         mockMvc.perform(delete("/events/RESUME07/progress"));
 
-        // "재접속"
         mockMvc.perform(get("/events/RESUME07"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(0))

--- a/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
@@ -108,12 +108,15 @@ class ResumeFlowTest {
         em.clear();
 
         String drawResult = mockMvc.perform(post("/events/RESUME09/capsules/draw"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.capsuleId").isNumber())
                 .andReturn().getResponse().getContentAsString();
         Long capsuleId = objectMapper.readTree(drawResult).path("data").path("capsuleId").asLong();
 
         mockMvc.perform(post("/events/RESUME09/capsules/select")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"capsuleId\":" + capsuleId + "}"));
+                .content("{\"capsuleId\":" + capsuleId + "}"))
+                .andExpect(status().isOk());
 
         // 선택 후에도 추가 뽑기 가능
         mockMvc.perform(post("/events/RESUME09/capsules/draw"))


### PR DESCRIPTION
## 📌 작업 개요
- 퀴즈 채점을 클라이언트 → 서버로 전환하고, 캡슐 선택 후에도 뽑기를 허용하도록 변경

---

## ✨ 주요 변경 사항

### 퀴즈 서버 채점 전환
- `POST /quiz/answer` 요청: `correct` + `remainingAttempts` → `selectedAnswer`로 변경
- 서버 `gradeAnswer()` 채점 로직 추가 (OBJECTIVE/OX: 정답 choiceText 비교, SUBJECTIVE: 허용 답안 대소문자 무시 비교)
- `remainingAttempts` 서버 관리 — 첫 시도 시 `playLimit`으로 초기화, 오답 시 차감, 정답/소진 시 null 리셋
- `GET /events/{eventUrl}` 응답에서 `answer` 필드 제거 (정답 노출 방지)
- `QUIZ_NO_ATTEMPTS_LEFT` 에러 코드 추가

### 캡슐 선택 후 뽑기 허용
- `CAPSULE_ALREADY_SELECTED` 에러 코드 및 select 차단 로직 제거
- 선택 후에도 남은 횟수만큼 뽑기 가능, 선택 변경도 자유

### 변경 파일
- `QuizService.java` — `submitAnswer()` 서버 채점 + `gradeAnswer()` 추가
- `QuizRequest.java` / `QuizResponse.java` — DTO 변경
- `EventResponse.java` — QuizItem에서 `answer` 필드 제거
- `BirthdayEventService.java` — buildQuizItem에서 answer 빌드 제거
- `CapsuleService.java` — select 차단 로직 제거
- `ErrorCode.java` — `CAPSULE_ALREADY_SELECTED` 제거, `QUIZ_NO_ATTEMPTS_LEFT` 추가

---

## 🖼️ 기능 살펴 보기
- [x] API 문서(요청, 응답)와 일치하는지 확인 — `docs/api-spec-open.md` 동시 업데이트 완료

---

## ✅ 작업 체크리스트
- [x] 기능별 예외 케이스 고려
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - `QuizFullFlowTest`: 3문제 × 3회 기회 (전부 오답 → 오답→정답 → 첫 시도 정답 → result 성공)
    - `CapsuleFullFlowTest`: 5회 뽑기 중 select → 추가 뽑기 → 재선택 시나리오
    - 기존 `QuizApiTest` 11건 + `CapsuleApiTest` 7건 + `ResumeFlowTest` 모두 통과

---

## 💬 기타 참고 사항
- Flutter 프론트 개발자와 회의 후 결정된 구조 변경
- 퀴즈 정답을 클라이언트에 내려주지 않으므로 보안성 향상
- 캡슐 select가 뽑기를 차단하지 않으므로 UX 자유도 향상

---

## 📎 관련 이슈 / 문서
- close #32
- API 명세: `docs/api-spec-open.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 서버 기반 퀴즈 채점 도입 — 정답 노출 제거 및 서버가 시도 횟수 관리

* **Bug Fixes**
  * 캡슐 선택 후에도 남은 기회가 있으면 뽑기 계속 가능하도록 개선
  * 퀴즈 답안 제출 흐름 안정화: 오답 시 시도 횟수 감소·정답 시 문제 종료/진행 처리

* **Documentation**
  * 퀴즈 요청/응답 계약 및 오류 코드(추가/삭제) 업데이트 안내

* **Tests**
  * 캡슐·퀴즈 통합 엔드투엔드 테스트 추가 및 기존 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->