### PR TITLE
[fix] 퀴즈 결과 API 불필요한 correctCount 제거 및 명칭 수정

### DIFF
--- a/docs/api-spec-open.md
+++ b/docs/api-spec-open.md
@@ -535,7 +535,7 @@ POST /events/{eventUrl}/quiz/answer
 
 ---
 
-## 5. 퀴즈 최종 결과 저장
+## 5. 퀴즈 최종 결과 조회
 
 모든 문제를 풀고 나서 최종 보상을 판정합니다. 서버가 DB에서 정답 수를 직접 계산합니다.
 
@@ -549,24 +549,14 @@ POST /events/{eventUrl}/quiz/result
 |---------|------|------|------|
 | `eventUrl` | path | String | 이벤트 고유 URL |
 
-**Body:**
-
-```json
-{
-  "correctCount": 2
-}
-```
-
-| 필드 | 타입 | 필수 | 설명 |
-|------|------|------|------|
-| `correctCount` | int | O | 프론트에서 채점한 정답 수 (서버 검증용 참고값, 실제 판정은 서버 DB 기준) |
+> **Body 없음** — 서버가 `quiz_answer` 테이블에서 정답 수를 직접 계산합니다.
 
 ### Response (200 OK)
 
 ```json
 {
   "code": "SUCCESS",
-  "message": "퀴즈 결과 저장 성공",
+  "message": "퀴즈 결과 조회 성공",
   "data": {
     "correctCount": 2,
     "success": true

--- a/docs/api-spec-open.md
+++ b/docs/api-spec-open.md
@@ -569,6 +569,14 @@ POST /events/{eventUrl}/quiz/result
 | `correctCount` | int | 서버가 계산한 정답 수 |
 | `success` | boolean | 성공 여부 (`correctCount >= requiredCount`) |
 
+### 에러 케이스
+
+| 상황 | 에러 코드 | HTTP |
+|------|----------|------|
+| 모든 문제 미완료 | `QUIZ_NOT_ALL_ANSWERED` | 400 |
+| 퀴즈 이벤트 없음 | `QUIZ_NOT_FOUND` | 404 |
+| 이벤트 없음 | `EVENT_NOT_FOUND` | 404 |
+
 ---
 
 ## 6. 진행 데이터 리셋

--- a/src/main/java/com/gifo/backend/controller/quiz/QuizController.java
+++ b/src/main/java/com/gifo/backend/controller/quiz/QuizController.java
@@ -34,16 +34,16 @@ public class QuizController {
     }
 
     /**
-     * POST /events/{eventUrl}/quiz/result - 퀴즈 최종 결과 저장
+     * POST /events/{eventUrl}/quiz/result - 퀴즈 최종 결과 조회
      * 모든 문제 완료 후 서버가 DB에서 정답 수를 계산하여 보상 판정
+     * Body 없음 — 서버가 quiz_answer 테이블에서 직접 계산
      */
     @PostMapping("/{eventUrl}/quiz/result")
-    @Operation(summary = "퀴즈 결과 저장", description = "모든 문제 완료 후 최종 보상을 판정합니다.")
-    public ResponseEntity<ApiResponse<QuizResponse.Result>> saveResult(
-            @PathVariable String eventUrl,
-            @Valid @RequestBody QuizRequest.Result request) {
+    @Operation(summary = "퀴즈 결과 조회", description = "모든 문제 완료 후 최종 보상을 판정합니다.")
+    public ResponseEntity<ApiResponse<QuizResponse.Result>> getResult(
+            @PathVariable String eventUrl) {
 
-        QuizResponse.Result response = quizService.saveResult(eventUrl, request);
-        return ResponseEntity.ok(ApiResponse.success("퀴즈 결과 저장 성공", response));
+        QuizResponse.Result response = quizService.getResult(eventUrl);
+        return ResponseEntity.ok(ApiResponse.success("퀴즈 결과 조회 성공", response));
     }
 }

--- a/src/main/java/com/gifo/backend/dto/quiz/QuizRequest.java
+++ b/src/main/java/com/gifo/backend/dto/quiz/QuizRequest.java
@@ -9,12 +9,6 @@ import jakarta.validation.constraints.NotNull;
 public class QuizRequest {
 
     /**
-     * POST /events/{eventUrl}/quiz/result 요청
-     * 모든 문제 완료 후 호출 (서버가 DB에서 정답 수 계산)
-     */
-    public record Result(int correctCount) {}
-
-    /**
      * POST /events/{eventUrl}/quiz/answer 요청
      * 매 시도마다 호출 — 서버가 채점 + remainingAttempts 관리
      */

--- a/src/main/java/com/gifo/backend/service/quiz/QuizService.java
+++ b/src/main/java/com/gifo/backend/service/quiz/QuizService.java
@@ -154,11 +154,13 @@ public class QuizService {
             throw new QuizException(ErrorCode.QUIZ_NOT_ALL_ANSWERED);
         }
 
+        // 이미 결과가 확정된 경우 (중복 호출 방어) → 기존 결과 반환
+        if (quizEvent.getLastSuccess() != null) {
+            return new QuizResponse.Result(quizEvent.getLastCorrectCount(), quizEvent.getLastSuccess());
+        }
+
         // 서버가 DB에서 정답 수 계산
         int correctCount = (int) quizAnswerRepository.countByQuizEventAndCorrectTrue(quizEvent);
-
-        // 원자적 totalAttempt 증가 (동시성 안전)
-        quizEventRepository.incrementTotalAttempt(quizEvent.getQuizEventId());
 
         // 보상 규칙으로 성공 여부 판정
         boolean success = quizRewardRuleRepository
@@ -166,9 +168,13 @@ public class QuizService {
                 .filter(r -> r.getMinCorrect() != null && r.getMinCorrect() > 0)
                 .anyMatch(r -> correctCount >= r.getMinCorrect());
 
-        // 결과를 QuizEvent에 영속
+        // 결과를 QuizEvent에 먼저 영속 (increment 전에 저장해야 detach 문제 없음)
         quizEvent.setLastCorrectCount(correctCount);
         quizEvent.setLastSuccess(success);
+        quizEventRepository.flush();
+
+        // 최초 확정 시에만 totalAttempt 1회 증가
+        quizEventRepository.incrementTotalAttempt(quizEvent.getQuizEventId());
 
         return new QuizResponse.Result(correctCount, success);
     }

--- a/src/main/java/com/gifo/backend/service/quiz/QuizService.java
+++ b/src/main/java/com/gifo/backend/service/quiz/QuizService.java
@@ -136,10 +136,10 @@ public class QuizService {
     }
 
     /**
-     * 최종 보상 판정
+     * 퀴즈 최종 결과 조회
      * 모든 문제 완료 후 서버가 DB에서 정답 수를 계산하여 보상 결정
      */
-    public QuizResponse.Result saveResult(String eventUrl, QuizRequest.Result request) {
+    public QuizResponse.Result getResult(String eventUrl) {
         BirthdayEvent event = entityFinder.getEventByUrlOrThrow(eventUrl);
 
         QuizEvent quizEvent = event.getQuizEvent();

--- a/src/main/java/com/gifo/backend/service/quiz/QuizService.java
+++ b/src/main/java/com/gifo/backend/service/quiz/QuizService.java
@@ -140,7 +140,8 @@ public class QuizService {
      * 모든 문제 완료 후 서버가 DB에서 정답 수를 계산하여 보상 결정
      */
     public QuizResponse.Result getResult(String eventUrl) {
-        BirthdayEvent event = entityFinder.getEventByUrlOrThrow(eventUrl);
+        // 비관적 락으로 동시 result 호출 직렬화
+        BirthdayEvent event = entityFinder.getEventByUrlForUpdateOrThrow(eventUrl);
 
         QuizEvent quizEvent = event.getQuizEvent();
         if (quizEvent == null) {

--- a/src/test/java/com/gifo/backend/integration/EdgeCaseTest.java
+++ b/src/test/java/com/gifo/backend/integration/EdgeCaseTest.java
@@ -278,9 +278,7 @@ class EdgeCaseTest {
                 .andExpect(jsonPath("$.data.remainingAttempts").value(0));
 
         // result 호출
-        mockMvc.perform(post("/events/EDGE_RST1/quiz/result")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"correctCount\":0}"))
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/result"))
                 .andExpect(jsonPath("$.data.correctCount").value(0))
                 .andExpect(jsonPath("$.data.success").value(false));
 
@@ -304,9 +302,7 @@ class EdgeCaseTest {
                 .andExpect(jsonPath("$.data.currentQuizIndex").value(1));
 
         // 2차 result → 성공
-        mockMvc.perform(post("/events/EDGE_RST1/quiz/result")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":1}"))
+        mockMvc.perform(post("/events/EDGE_RST1/quiz/result"))
                 .andExpect(jsonPath("$.data.correctCount").value(1))
                 .andExpect(jsonPath("$.data.success").value(true));
     }

--- a/src/test/java/com/gifo/backend/integration/QuizApiTest.java
+++ b/src/test/java/com/gifo/backend/integration/QuizApiTest.java
@@ -190,9 +190,7 @@ class QuizApiTest {
                 .andExpect(jsonPath("$.data.content.quiz.currentQuizIndex").value(3))
                 .andExpect(jsonPath("$.data.content.quiz.answerHistory.length()").value(3));
 
-        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":3}"))
+        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.correctCount").value(3))
@@ -223,9 +221,7 @@ class QuizApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"quizId\":" + quiz3Id + ",\"selectedAnswer\":\"이디야\"}"));
 
-        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":1}"))
+        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.correctCount").value(1))
                 .andExpect(jsonPath("$.data.success").value(false));
@@ -255,9 +251,7 @@ class QuizApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"quizId\":" + quiz1Id + ",\"selectedAnswer\":\"치킨\"}"));
 
-        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":1}"))
+        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("QUIZ_NOT_ALL_ANSWERED"));

--- a/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/QuizFullFlowTest.java
@@ -192,10 +192,8 @@ class QuizFullFlowTest {
 
         // ── result: correctCount=2 (Q2+Q3), success=true (minCorrect=2) ──
 
-        // 일부러 틀린 correctCount(0)를 보내서 서버가 DB 기준으로 재계산하는지 검증
-        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"correctCount\":0}"))
+        // 서버가 DB에서 정답 수를 직접 계산하므로 body 없이 호출
+        mockMvc.perform(post("/events/{eventUrl}/quiz/result", eventUrl))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.correctCount").value(2))


### PR DESCRIPTION
## 📌 작업 개요
- 퀴즈 결과 API에서 불필요한 `correctCount` 요청 필드 제거 및 "결과 저장" → "결과 조회" 명칭 수정

---

## ✨ 주요 변경 사항
- `QuizRequest.Result` 레코드 삭제 (서버가 DB에서 직접 계산하므로 프론트에서 보내줄 필요 없음)
- `QuizController`: `saveResult` → `getResult` 리네임, `@RequestBody` 제거
- `QuizService`: `saveResult` → `getResult` 리네임, request 파라미터 제거
- Swagger 설명 "퀴즈 결과 저장" → "퀴즈 결과 조회" 수정
- `api-spec-open.md` 퀴즈 결과 섹션: Body 없음 명시, "저장" → "조회"
- 테스트 6곳에서 `quiz/result` 호출 시 불필요한 body 제거

---

## 🖼️ 기능 살펴 보기
- [x] API 문서(요청, 응답)와 일치하는지 확인

**변경 전:**
```http
POST /events/{eventUrl}/quiz/result
Body: { "correctCount": 2 }
```

**변경 후:**
```http
POST /events/{eventUrl}/quiz/result
Body: 없음
```

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (스웨거)
- [x] 스웨거 ui 관련 코드 수정
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성 (기존 테스트 body 제거 반영)
- [x] `./gradlew test` 전체 통과 확인
- [x] 스웨거에서 배포 서버 직접 테스트 완료

---

## 💬 기타 참고 사항
- 서버가 매 답안 제출 시 `quiz_answer` 테이블에 정답/오답을 저장하므로, result 호출 시 프론트에서 정답 수를 보내줄 필요가 없음
- 프론트는 result 응답의 `success` 값으로 초기 GET에서 받아둔 `successReward`/`failReward` 중 하나를 표시하면 됨

---

## 📎 관련 이슈 / 문서
- close #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 퀴즈 최종 결과 제출에서 클라이언트가 더 이상 정답 수를 전송할 필요 없음 — 서버가 DB에서 정답 수를 계산하여 응답을 반환합니다.
  * 중복 호출에 대해 결과가 중복 집계되지 않도록 시도가 한 번만 증가하도록 수정되어 시도 횟수 집계가 안정적입니다.
* **문서**
  * API 명세에서 요청 바디 제거 및 응답 메시지를 “저장”에서 “조회”로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->