### PR TITLE
[feat] Curate service

### DIFF
--- a/src/main/java/com/gifo/backend/config/JacksonConfig.java
+++ b/src/main/java/com/gifo/backend/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.gifo.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/gifo/backend/curate/AzureImageGenerationService.java
+++ b/src/main/java/com/gifo/backend/curate/AzureImageGenerationService.java
@@ -1,0 +1,108 @@
+package com.gifo.backend.curate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ReactorClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AzureImageGenerationService {
+
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.builder()
+            .requestFactory(new ReactorClientHttpRequestFactory(
+                    HttpClient.create()
+                            .responseTimeout(Duration.ofMinutes(5))
+            ))
+            .build();
+
+    @Value("${AZURE_OPENAI_IMAGE_GENERATION_URL:}")
+    private String imageGenerationUrl;
+
+    @Value("${AZURE_OPENAI_API_KEY:}")
+    private String apiKey;
+
+    @Value("${AZURE_OPENAI_IMAGE_MODEL:}")
+    private String imageModel;
+
+    @Value("${AZURE_OPENAI_IMAGE_SIZE:512x512}")
+    private String imageSize;
+
+    public String generateImageUrl(String prompt) {
+        if (!StringUtils.hasText(imageGenerationUrl) || !StringUtils.hasText(apiKey)) {
+            log.warn("[Curate-Image] image generation 설정 누락: AZURE_OPENAI_IMAGE_GENERATION_URL/API_KEY");
+            return null;
+        }
+
+        try {
+            log.info("[Curate-Image] 이미지 생성 요청 시작 - endpoint={}, model={}, promptLength={}",
+                    imageGenerationUrl, imageModel, prompt != null ? prompt.length() : 0);
+
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("prompt", prompt);
+            body.put("size", imageSize);
+
+            // deployment 경로를 직접 쓰는 경우 model이 필수는 아니지만, 설정돼 있으면 함께 전달
+            if (StringUtils.hasText(imageModel)) {
+                body.put("model", imageModel);
+            }
+
+            // FLUX 배포는 b64_json 전용 응답만 지원하므로 response_format을 지정하지 않음
+            String responseText = requestImage(body);
+
+            if (!StringUtils.hasText(responseText)) {
+                log.warn("[Curate-Image] 이미지 생성 응답이 비어 있음");
+                return null;
+            }
+
+            JsonNode root = objectMapper.readTree(responseText);
+            JsonNode data = root.path("data");
+            if (data.isArray() && !data.isEmpty()) {
+                JsonNode first = data.get(0);
+                String url = first.path("url").asText("");
+                if (StringUtils.hasText(url)) {
+                    log.info("[Curate-Image] 이미지 생성 성공 - url={}", url);
+                    return url;
+                }
+                String b64 = first.path("b64_json").asText("");
+                if (StringUtils.hasText(b64)) {
+                    String dataUri = "data:image/png;base64," + b64;
+                    log.info("[Curate-Image] 이미지 생성 성공 - b64_json 수신(data-uri 변환), size={}", b64.length());
+                    return dataUri;
+                }
+            }
+
+            log.warn("[Curate-Image] 이미지 URL 추출 실패 - response={}", responseText);
+            return null;
+        } catch (Exception e) {
+            log.warn("[Curate-Image] 이미지 생성 요청 실패 - message={}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private String requestImage(Map<String, Object> body) {
+        return restClient.post()
+                .uri(imageGenerationUrl)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header("api-key", apiKey)
+                .body(body)
+                .retrieve()
+                .body(String.class);
+    }
+}
+

--- a/src/main/java/com/gifo/backend/curate/CurateController.java
+++ b/src/main/java/com/gifo/backend/curate/CurateController.java
@@ -1,6 +1,7 @@
 package com.gifo.backend.curate;
 
 import com.gifo.backend.curate.dto.CurateResponseDto;
+import com.gifo.backend.curate.dto.CurateImageEnrichRequestDto;
 import com.gifo.backend.curate.dto.SurveyRequestDto;
 import com.gifo.backend.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,5 +26,19 @@ public class CurateController {
     public ApiResponse<CurateResponseDto> curate(@Valid @RequestBody SurveyRequestDto request) {
         CurateResponseDto data = curateService.curate(request);
         return ApiResponse.success("큐레이션 생성 완료", data);
+    }
+
+    @PostMapping("/create-base")
+    @Operation(summary = "기본 큐레이션 생성(이미지 제외)", description = "텍스트/게임/갤러리 구조만 먼저 생성합니다.")
+    public ApiResponse<CurateResponseDto> curateBase(@Valid @RequestBody SurveyRequestDto request) {
+        CurateResponseDto data = curateService.curateWithoutImages(request);
+        return ApiResponse.success("기본 큐레이션 생성 완료", data);
+    }
+
+    @PostMapping("/enrich-images")
+    @Operation(summary = "큐레이션 이미지 생성", description = "기본 큐레이션의 gallery 항목에 이미지 URL(data URI 포함)을 바인딩합니다.")
+    public ApiResponse<CurateResponseDto> enrichImages(@Valid @RequestBody CurateImageEnrichRequestDto request) {
+        CurateResponseDto data = curateService.enrichImages(request.getSurvey(), request.getCurate());
+        return ApiResponse.success("큐레이션 이미지 생성 완료", data);
     }
 }

--- a/src/main/java/com/gifo/backend/curate/CurateController.java
+++ b/src/main/java/com/gifo/backend/curate/CurateController.java
@@ -1,0 +1,29 @@
+package com.gifo.backend.curate;
+
+import com.gifo.backend.curate.dto.CurateResponseDto;
+import com.gifo.backend.curate.dto.SurveyRequestDto;
+import com.gifo.backend.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/curate")
+@Tag(name = "큐레이션 API", description = "설문 기반 AI 개인화 큐레이션")
+@RequiredArgsConstructor
+public class CurateController {
+
+    private final CurateService curateService;
+
+    @PostMapping("/create")
+    @Operation(summary = "큐레이션 생성", description = "설문(관계/상황/톤/연령/이름)을 받아 Azure OpenAI로 프론트엔드용 JSON 템플릿을 생성합니다.")
+    public ApiResponse<CurateResponseDto> curate(@Valid @RequestBody SurveyRequestDto request) {
+        CurateResponseDto data = curateService.curate(request);
+        return ApiResponse.success("큐레이션 생성 완료", data);
+    }
+}

--- a/src/main/java/com/gifo/backend/curate/CurateService.java
+++ b/src/main/java/com/gifo/backend/curate/CurateService.java
@@ -1,0 +1,160 @@
+package com.gifo.backend.curate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gifo.backend.curate.dto.CurateResponseDto;
+import com.gifo.backend.curate.dto.SurveyRequestDto;
+import com.gifo.backend.curate.dto.content.*;
+import com.gifo.backend.curate.prompt.CuratePromptLoader;
+import com.gifo.backend.global.exception.CustomException;
+import com.gifo.backend.global.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CurateService {
+
+    private static final String DEFAULT_BGM = "track_sweet_01";
+
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+    private final CuratePromptLoader promptLoader;
+
+    public CurateResponseDto curate(SurveyRequestDto survey) {
+        String userMessage = promptLoader.loadPrompt(survey);
+
+        try {
+            String raw = chatClient.prompt()
+                    .user(userMessage)
+                    .call()
+                    .content();
+
+            if (raw == null || raw.isBlank()) {
+                throw new CustomException(ErrorCode.AI_CURATE_ERROR, "AI 응답이 비어 있습니다.");
+            }
+
+            String json = stripMarkdownJson(raw);
+            CurateResponseDto result = objectMapper.readValue(json, CurateResponseDto.class);
+
+            if (result == null) {
+                throw new CustomException(ErrorCode.AI_CURATE_ERROR, "AI 응답 파싱 결과가 비어 있습니다.");
+            }
+
+            if (result.getBgm() == null || result.getBgm().isBlank()) {
+                result.setBgm(DEFAULT_BGM);
+            }
+            if (result.getContent() == null || !hasAnyGame(result.getContent())) {
+                result.setContent(buildExampleContent());
+            }
+            return result;
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("AI 큐레이션 생성 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.AI_CURATE_ERROR,
+                    e.getMessage() != null ? e.getMessage() : ErrorCode.AI_CURATE_ERROR.getDefaultMessage());
+        }
+    }
+
+    /**
+     * LLM이 ```json ... ``` 형태로 감싸서 반환한 경우 껍질을 제거.
+     */
+    private String stripMarkdownJson(String raw) {
+        String trimmed = raw.trim();
+        if (trimmed.startsWith("```")) {
+            int start = trimmed.indexOf("\n");
+            if (start != -1) {
+                int end = trimmed.lastIndexOf("```");
+                if (end > start) {
+                    trimmed = trimmed.substring(start + 1, end).trim();
+                } else {
+                    trimmed = trimmed.substring(start + 1).trim();
+                }
+            } else {
+                trimmed = trimmed.replaceFirst("^```\\w*", "").replaceFirst("```\\s*$", "").trim();
+            }
+        }
+        return trimmed;
+    }
+
+    private boolean hasAnyGame(ContentDto content) {
+        return content != null && (
+                (content.getGacha() != null && content.getGacha().getList() != null && !content.getGacha().getList().isEmpty())
+                        || (content.getQuiz() != null && content.getQuiz().getList() != null && !content.getQuiz().getList().isEmpty())
+                        || content.getUnboxing() != null
+        );
+    }
+
+    /** LLM이 content를 안 넣었을 때만 쓰는 기본 content (가챌, 퀴즈, 선물 개봉) - 방어 로직 */
+    private ContentDto buildExampleContent() {
+        GachaDto gacha = GachaDto.builder()
+                .playCount(3)
+                .list(List.of(
+                        GachaItemDto.builder()
+                                .itemName("닌텐도 스위치2")
+                                .imageUrl("https://example.com/images/switch.png")
+                                .percent(0.001)
+                                .percentOpen(false)
+                                .build()
+                ))
+                .build();
+
+        QuizDto quiz = QuizDto.builder()
+                .successReward(QuizRewardDto.builder()
+                        .requiredCount(3)
+                        .itemName("특급 한우 세트")
+                        .imageUrl("https://example.com/images/beef.png")
+                        .build())
+                .failReward(QuizRewardDto.builder()
+                        .itemName("비타500")
+                        .imageUrl("https://example.com/images/vita500.png")
+                        .build())
+                .list(List.of(
+                        QuizItemDto.builder()
+                                .quizId(1)
+                                .type("multiple_choice")
+                                .title("내가 제일 좋아하는 음식은?")
+                                .imageUrl("https://example.com/images/food.png")
+                                .description("힌트: 매콤한 소스가 특징입니다.")
+                                .hint("어제 저녁에도 먹었어요!")
+                                .options(List.of("치킨", "마라탕", "초밥", "삼겹살", "파스타"))
+                                .answer(List.of("마라탕"))
+                                .playLimit(2)
+                                .build(),
+                        QuizItemDto.builder()
+                                .quizId(2)
+                                .type("ox")
+                                .title("나는 아침형 인간이다.")
+                                .imageUrl("https://example.com/images/morning.png")
+                                .description("진실 혹은 거짓!")
+                                .hint("새벽까지 게임하는 걸 좋아해요.")
+                                .options(List.of())
+                                .answer(List.of("X"))
+                                .playLimit(1)
+                                .build()
+                ))
+                .build();
+
+        UnboxingDto unboxing = UnboxingDto.builder()
+                .beforeOpen(UnboxingPhaseDto.builder()
+                        .imageUrl("https://example.com/images/gift_box.png")
+                        .description("상자 안에 무엇이 들어있을까요? 클릭해서 확인해보세요!")
+                        .build())
+                .afterOpen(UnboxingAfterDto.builder()
+                        .itemName("아이패드 프로 M4")
+                        .imageUrl("https://example.com/images/ipad.png")
+                        .build())
+                .build();
+
+        return ContentDto.builder()
+                .gacha(gacha)
+                .quiz(quiz)
+                .unboxing(unboxing)
+                .build();
+    }
+}

--- a/src/main/java/com/gifo/backend/curate/CurateService.java
+++ b/src/main/java/com/gifo/backend/curate/CurateService.java
@@ -2,6 +2,7 @@ package com.gifo.backend.curate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gifo.backend.curate.dto.CurateResponseDto;
+import com.gifo.backend.curate.dto.GalleryItemDto;
 import com.gifo.backend.curate.dto.SurveyRequestDto;
 import com.gifo.backend.curate.dto.content.*;
 import com.gifo.backend.curate.prompt.CuratePromptLoader;
@@ -24,9 +25,32 @@ public class CurateService {
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
     private final CuratePromptLoader promptLoader;
+    private final AzureImageGenerationService imageGenerationService;
 
     public CurateResponseDto curate(SurveyRequestDto survey) {
+        boolean withImages = Boolean.TRUE.equals(survey.getGenerateGalleryImages());
+        return curateInternal(survey, withImages);
+    }
+
+    public CurateResponseDto curateWithoutImages(SurveyRequestDto survey) {
+        return curateInternal(survey, false);
+    }
+
+    public CurateResponseDto enrichImages(SurveyRequestDto survey, CurateResponseDto curate) {
+        if (curate == null) {
+            throw new CustomException(ErrorCode.AI_CURATE_ERROR, "이미지 생성 대상 큐레이션 데이터가 비어 있습니다.");
+        }
+        enrichGalleryImages(curate, survey);
+        return curate;
+    }
+
+    private CurateResponseDto curateInternal(SurveyRequestDto survey, boolean withImages) {
+        log.info("[Curate] 요청 수신 - relationship={}, situation={}, tone={}, targetAge={}, targetName={}",
+                survey.getRelationship(), survey.getSituation(), survey.getTone(),
+                survey.getTargetAge(), survey.getTargetName());
+
         String userMessage = promptLoader.loadPrompt(survey);
+        log.debug("[Curate] 생성된 프롬프트 (length={}): {}", userMessage.length(), userMessage);
 
         try {
             String raw = chatClient.prompt()
@@ -38,7 +62,12 @@ public class CurateService {
                 throw new CustomException(ErrorCode.AI_CURATE_ERROR, "AI 응답이 비어 있습니다.");
             }
 
+            String rawPreview = raw.length() > 1000 ? raw.substring(0, 1000) + "..." : raw;
+            log.debug("[Curate] Azure OpenAI 원본 응답 (preview): {}", rawPreview);
+
             String json = stripMarkdownJson(raw);
+            log.debug("[Curate] JSON 추출 결과 (length={}): {}", json.length(), json);
+
             CurateResponseDto result = objectMapper.readValue(json, CurateResponseDto.class);
 
             if (result == null) {
@@ -51,11 +80,26 @@ public class CurateService {
             if (result.getContent() == null || !hasAnyGame(result.getContent())) {
                 result.setContent(buildExampleContent());
             }
+            // 갤러리는 1장만 사용하도록 서버에서 최종 강제
+            limitGalleryToOne(result);
+
+            if (withImages) {
+                enrichGalleryImages(result, survey);
+            }
+
+            log.info("[Curate] 큐레이션 생성 완료 - user={}, bgm={}, hasGallery={}, hasGacha={}, hasQuiz={}, hasUnboxing={}",
+                    result.getUser(),
+                    result.getBgm(),
+                    result.getGallery() != null && !result.getGallery().isEmpty(),
+                    result.getContent() != null && result.getContent().getGacha() != null,
+                    result.getContent() != null && result.getContent().getQuiz() != null,
+                    result.getContent() != null && result.getContent().getUnboxing() != null
+            );
             return result;
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.warn("AI 큐레이션 생성 실패: {}", e.getMessage());
+            log.warn("AI 큐레이션 생성 실패", e);
             throw new CustomException(ErrorCode.AI_CURATE_ERROR,
                     e.getMessage() != null ? e.getMessage() : ErrorCode.AI_CURATE_ERROR.getDefaultMessage());
         }
@@ -80,6 +124,80 @@ public class CurateService {
             }
         }
         return trimmed;
+    }
+
+    private void enrichGalleryImages(CurateResponseDto result, SurveyRequestDto survey) {
+        if (result.getGallery() == null || result.getGallery().isEmpty()) {
+            log.info("[Curate-Image] gallery 항목이 없어 이미지 생성을 건너뜁니다.");
+            return;
+        }
+
+        log.info("[Curate-Image] gallery 이미지 생성 시작 - itemCount={}", result.getGallery().size());
+
+        for (int i = 0; i < result.getGallery().size(); i++) {
+            GalleryItemDto galleryItem = result.getGallery().get(i);
+            try {
+                String prompt = buildImagePrompt(survey, galleryItem);
+                log.info("[Curate-Image] item 이미지 생성 요청 - index={}, title={}, descLength={}, promptLength={}",
+                        i,
+                        galleryItem.getTitle(),
+                        galleryItem.getDescription() != null ? galleryItem.getDescription().length() : 0,
+                        prompt.length());
+
+                String generatedUrl = imageGenerationService.generateImageUrl(prompt);
+                if (generatedUrl != null && !generatedUrl.isBlank()) {
+                    galleryItem.setImageUrl(generatedUrl);
+                    log.info("[Curate-Image] item 이미지 바인딩 완료 - index={}, title={}, url={}",
+                            i, galleryItem.getTitle(), generatedUrl);
+                } else {
+                    log.warn("[Curate-Image] item 이미지 생성 결과 없음 - index={}, title={}",
+                            i, galleryItem.getTitle());
+                }
+            } catch (Exception e) {
+                log.warn("[Curate-Image] gallery 이미지 바인딩 실패 - index={}, title={}", i, galleryItem.getTitle(), e);
+            }
+        }
+
+        log.info("[Curate-Image] gallery 이미지 생성 종료");
+    }
+
+    private String buildImagePrompt(SurveyRequestDto survey, GalleryItemDto galleryItem) {
+        return """
+                Create a warm, shared-memory scene image for a memory gallery.
+                Relationship: %s
+                Situation: %s
+                Tone: %s
+                Target age group: %s
+                Target name: %s
+                Memory title: %s
+                Memory description: %s
+                Requirements:
+                - Depict a real moment they shared together (event/place/time/interaction).
+                - Focus on people and atmosphere, not products or gifts.
+                - Do NOT depict gift boxes, product shots, rewards, or item catalog style.
+                Style: clean, emotionally touching, realistic illustration, no text, no watermark.
+                """.formatted(
+                nullSafe(survey.getRelationship()),
+                nullSafe(survey.getSituation()),
+                nullSafe(survey.getTone()),
+                nullSafe(survey.getTargetAge()),
+                nullSafe(survey.getTargetName()),
+                nullSafe(galleryItem.getTitle()),
+                nullSafe(galleryItem.getDescription())
+        );
+    }
+
+    private String nullSafe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private void limitGalleryToOne(CurateResponseDto result) {
+        if (result.getGallery() == null || result.getGallery().isEmpty()) {
+            return;
+        }
+        if (result.getGallery().size() > 1) {
+            result.setGallery(List.of(result.getGallery().get(0)));
+        }
     }
 
     private boolean hasAnyGame(ContentDto content) {

--- a/src/main/java/com/gifo/backend/curate/dto/CurateImageEnrichRequestDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/CurateImageEnrichRequestDto.java
@@ -1,0 +1,28 @@
+package com.gifo.backend.curate.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "큐레이션 결과에 이미지 생성만 추가하기 위한 요청")
+public class CurateImageEnrichRequestDto {
+
+    @Valid
+    @NotNull(message = "설문 정보(survey)는 필수입니다.")
+    private SurveyRequestDto survey;
+
+    @Valid
+    @NotNull(message = "큐레이션 결과(curate)는 필수입니다.")
+    private CurateResponseDto curate;
+}
+

--- a/src/main/java/com/gifo/backend/curate/dto/CurateResponseDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/CurateResponseDto.java
@@ -1,0 +1,39 @@
+package com.gifo.backend.curate.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gifo.backend.curate.dto.content.ContentDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "프론트엔드 바인딩용 큐레이션 결과 (request_body 항목 1개에 해당)")
+public class CurateResponseDto {
+
+    @Schema(description = "사용자의 고유 성함 또는 닉네임")
+    private String user;
+
+    @JsonProperty("sub_title")
+    @Schema(description = "페이지 상단 메인 테마 문구")
+    private String subTitle;
+
+    @Schema(description = "BGM 트랙 ID (예: track_sweet_01)")
+    private String bgm;
+
+    @Schema(description = "추억 갤러리 목록 (2~3개 권장)")
+    private List<GalleryItemDto> gallery;
+
+    @Schema(description = "인터랙티브 콘텐츠 (가챌, 퀴즈, 선물 개봉)")
+    private ContentDto content;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/GalleryItemDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/GalleryItemDto.java
@@ -1,0 +1,30 @@
+package com.gifo.backend.curate.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "갤러리 항목 (추억 갤러리 섹션)")
+public class GalleryItemDto {
+
+    @Schema(description = "사진 제목")
+    private String title;
+
+    @JsonProperty("image_url")
+    @Schema(description = "이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "사진에 대한 설명 문구")
+    private String description;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/SurveyRequestDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/SurveyRequestDto.java
@@ -34,4 +34,8 @@ public class SurveyRequestDto {
 
     @Schema(description = "대상을 부를 이름 (선택, 개인화 문구에 반영)")
     private String targetName;
+
+    @Schema(description = "추억 갤러리 이미지 생성 여부 (체크한 경우에만 이미지 생성)")
+    @Builder.Default
+    private Boolean generateGalleryImages = false;
 }

--- a/src/main/java/com/gifo/backend/curate/dto/SurveyRequestDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/SurveyRequestDto.java
@@ -1,0 +1,37 @@
+package com.gifo.backend.curate.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "개인화 큐레이션 설문 요청")
+public class SurveyRequestDto {
+
+    @NotBlank(message = "대상과의 관계를 선택해주세요.")
+    @Schema(description = "대상과의 관계", example = "연인", allowableValues = {"연인", "친구", "가족", "동료"})
+    private String relationship;
+
+    @NotBlank(message = "상황을 선택해주세요.")
+    @Schema(description = "상황", example = "생일", allowableValues = {"생일", "축하", "위로", "응원", "사과"})
+    private String situation;
+
+    @NotBlank(message = "톤을 선택해주세요.")
+    @Schema(description = "톤", example = "감동", allowableValues = {"장난", "감동", "담백"})
+    private String tone;
+
+    @NotBlank(message = "대상의 연령을 입력해주세요.")
+    @Schema(description = "대상 연령", example = "20대")
+    private String targetAge;
+
+    @Schema(description = "대상을 부를 이름 (선택, 개인화 문구에 반영)")
+    private String targetName;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/ContentDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/ContentDto.java
@@ -1,0 +1,21 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContentDto {
+
+    private GachaDto gacha;
+    private QuizDto quiz;
+    private UnboxingDto unboxing;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/GachaDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/GachaDto.java
@@ -1,0 +1,25 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GachaDto {
+
+    @JsonProperty("play_count")
+    private Integer playCount;
+
+    private List<GachaItemDto> list;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/GachaItemDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/GachaItemDto.java
@@ -1,0 +1,29 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GachaItemDto {
+
+    @JsonProperty("item_name")
+    private String itemName;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    private Double percent;
+
+    @JsonProperty("percent_open")
+    private Boolean percentOpen;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/QuizDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/QuizDto.java
@@ -1,0 +1,28 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizDto {
+
+    @JsonProperty("success_reward")
+    private QuizRewardDto successReward;
+
+    @JsonProperty("fail_reward")
+    private QuizRewardDto failReward;
+
+    private List<QuizItemDto> list;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/QuizItemDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/QuizItemDto.java
@@ -1,0 +1,41 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizItemDto {
+
+    @JsonProperty("quiz_id")
+    private Integer quizId;
+
+    private String type;
+
+    private String title;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    private String description;
+
+    private String hint;
+
+    private List<String> options;
+
+    private List<String> answer;
+
+    @JsonProperty("play_limit")
+    private Integer playLimit;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/QuizRewardDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/QuizRewardDto.java
@@ -1,0 +1,27 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizRewardDto {
+
+    @JsonProperty("required_count")
+    private Integer requiredCount;
+
+    @JsonProperty("item_name")
+    private String itemName;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/UnboxingAfterDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/UnboxingAfterDto.java
@@ -1,0 +1,24 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnboxingAfterDto {
+
+    @JsonProperty("item_name")
+    private String itemName;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/UnboxingDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/UnboxingDto.java
@@ -1,0 +1,24 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnboxingDto {
+
+    @JsonProperty("before_open")
+    private UnboxingPhaseDto beforeOpen;
+
+    @JsonProperty("after_open")
+    private UnboxingAfterDto afterOpen;
+}

--- a/src/main/java/com/gifo/backend/curate/dto/content/UnboxingPhaseDto.java
+++ b/src/main/java/com/gifo/backend/curate/dto/content/UnboxingPhaseDto.java
@@ -1,0 +1,23 @@
+package com.gifo.backend.curate.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnboxingPhaseDto {
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    private String description;
+}

--- a/src/main/java/com/gifo/backend/curate/prompt/CuratePromptLoader.java
+++ b/src/main/java/com/gifo/backend/curate/prompt/CuratePromptLoader.java
@@ -1,0 +1,95 @@
+package com.gifo.backend.curate.prompt;
+
+import com.gifo.backend.curate.dto.SurveyRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 큐레이션용 프롬프트를 리소스에서 로드하고 변수를 치환합니다.
+ * 새 게임 추가 시: prompts/games/{게임키}.txt 파일만 추가하고 GAME_KEYS에 키를 등록하면 됩니다.
+ */
+@Slf4j
+@Component
+public class CuratePromptLoader {
+
+    private static final String BASE_PROMPT_PATH = "prompts/curate-base.txt";
+    private static final String GAMES_DIR = "prompts/games/";
+    private static final String BGM_LIST_PATH = "prompts/bgm-list.txt";
+    private static final String GAME_SPECS_PLACEHOLDER = "{{game_specs}}";
+    private static final String BGM_LIST_PLACEHOLDER = "{{bgm_list}}";
+
+    private static final List<String> GAME_KEYS = List.of("gacha", "quiz", "unboxing");
+
+    public String loadPrompt(SurveyRequestDto survey) {
+        Map<String, String> variables = Map.of(
+                "relationship", nullToEmpty(survey.getRelationship()),
+                "situation", nullToEmpty(survey.getSituation()),
+                "tone", nullToEmpty(survey.getTone()),
+                "targetAge", nullToEmpty(survey.getTargetAge()),
+                "targetName", survey.getTargetName() != null && !survey.getTargetName().isBlank()
+                        ? survey.getTargetName()
+                        : "(없음)"
+        );
+        return loadPrompt(variables);
+    }
+
+    public String loadPrompt(Map<String, String> variables) {
+        String base = loadResource(BASE_PROMPT_PATH);
+        if (base == null) {
+            throw new IllegalStateException("Base prompt not found: " + BASE_PROMPT_PATH);
+        }
+
+        String gameSpecs = loadGameSpecs();
+        String bgmList = loadBgmList();
+        String prompt = base
+                .replace(GAME_SPECS_PLACEHOLDER, gameSpecs)
+                .replace(BGM_LIST_PLACEHOLDER, bgmList);
+
+        for (Map.Entry<String, String> e : variables.entrySet()) {
+            prompt = prompt.replace("{{" + e.getKey() + "}}", e.getValue());
+        }
+
+        return prompt.trim();
+    }
+
+    private String loadBgmList() {
+        String content = loadResource(BGM_LIST_PATH);
+        return content != null ? content.trim() : "track_sweet_01 (기본)";
+    }
+
+    /** 등록된 게임 스펙 파일들을 순서대로 읽어 하나의 문자열로 합칩니다. */
+    private String loadGameSpecs() {
+        return GAME_KEYS.stream()
+                .map(key -> {
+                    String path = GAMES_DIR + key + ".txt";
+                    String content = loadResource(path);
+                    return content != null ? content.trim() : "";
+                })
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining("\n\n"));
+    }
+
+    private String loadResource(String path) {
+        try {
+            ClassPathResource resource = new ClassPathResource(path);
+            try (InputStream is = resource.getInputStream()) {
+                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            log.warn("Prompt resource not found or unreadable: {}", path);
+            return null;
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s != null ? s : "";
+    }
+}

--- a/src/main/java/com/gifo/backend/global/ErrorCode.java
+++ b/src/main/java/com/gifo/backend/global/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증 실패"),
 
     // 외부 API 오류
-    NAVER_API_ERROR(HttpStatus.BAD_GATEWAY, "네이버 쇼핑 API 호출에 실패했습니다.");
+    NAVER_API_ERROR(HttpStatus.BAD_GATEWAY, "네이버 쇼핑 API 호출에 실패했습니다."),
+
+    // AI 큐레이션 오류
+    AI_CURATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI 큐레이션 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String defaultMessage;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
       openai:
         api-key: ${AZURE_OPENAI_API_KEY}
         endpoint: ${AZURE_OPENAI_ENDPOINT}
+        client:
+          http:
+            connect-timeout: 30s
+            response-timeout: 300s
         chat:
           options:
             deployment-name: ${AZURE_OPENAI_DEPLOYMENT_NAME}

--- a/src/main/resources/prompts/bgm-list.txt
+++ b/src/main/resources/prompts/bgm-list.txt
@@ -1,0 +1,3 @@
+track_sweet_01 (달콤·연인·생일)
+track_cheerful_01 (밝은·축하·응원)
+track_calm_01 (담백·위로·사과)

--- a/src/main/resources/prompts/curate-base.txt
+++ b/src/main/resources/prompts/curate-base.txt
@@ -1,0 +1,27 @@
+# 개인화 선물 큐레이션 · 프라이빗 이벤트 페이지용 JSON 생성 지시
+
+당신은 사용자 입력에 맞는 이벤트 페이지 데이터를 **JSON만** 출력하는 어시스턴트입니다. 설명·마크다운·추가 필드는 절대 넣지 마세요.
+
+## 입력 조건
+- 대상과의 관계: {{relationship}}
+- 상황: {{situation}}
+- 톤: {{tone}}
+- 대상 연령: {{targetAge}}
+- 부를 이름(선택): {{targetName}}
+
+## 기본 출력 (반드시 포함)
+1. **user**: 부를 이름이 있으면 그 이름, 없으면 "당신" 등 호칭.
+2. **sub_title**: 위 조건에 맞는 한국어 메인 테마 문구 한 문장 (감동·개인화).
+3. **bgm**: 아래 목록 중 정확히 하나만 사용 (필수, null 금지).
+   {{bgm_list}}
+4. **gallery**: 2개. 각 항목: title, image_url, description. image_url은 https://example.com/... 형태 placeholder.
+
+## content (게임 콘텐츠)
+**content** 필드를 반드시 넣어줘. 아래 게임 스펙 중 **무작위로 1개** 골라, 관계·상황·톤에 맞는 내용으로 채워줘. 선택하지 않은 게임은 content 안에 키를 넣지 마.
+
+{{game_specs}}
+
+## 공통 규칙
+- 모든 image_url은 https://example.com/... 형태 placeholder.
+- 필드명은 스펙 그대로 snake_case (sub_title, image_url, item_name, play_count, success_reward, fail_reward, before_open, after_open 등).
+- 출력은 반드시 JSON만. 다른 텍스트 없음.

--- a/src/main/resources/prompts/curate-base.txt
+++ b/src/main/resources/prompts/curate-base.txt
@@ -14,7 +14,14 @@
 2. **sub_title**: 위 조건에 맞는 한국어 메인 테마 문구 한 문장 (감동·개인화).
 3. **bgm**: 아래 목록 중 정확히 하나만 사용 (필수, null 금지).
    {{bgm_list}}
-4. **gallery**: 2개. 각 항목: title, image_url, description. image_url은 https://example.com/... 형태 placeholder.
+4. **gallery**: 1개. 각 항목: title, image_url, description. image_url은 https://example.com/... 형태 placeholder.
+   - gallery는 반드시 "함께 보낸 추억의 장면"이어야 함.
+   - 제목/설명은 순간 중심으로 작성하고, 매 요청마다 표현을 다양하게 바꿔야 함.
+   - 아래처럼 동일한 패턴/문구를 반복하지 말 것:
+     "친구와 함께했던 여름", "우리가 함께했던 졸업식"
+   - title은 구체적인 장면/시간/장소를 드러내는 한국어 문장형으로 작성.
+   - description은 title을 보완하는 디테일(감정, 대화, 분위기, 행동)을 1문장으로 작성.
+   - 금지: 선물/상품/아이템/보상/상자 소개 문구 (예: "선물 상자", "아이템 모음", "보상", "추천 상품").
 
 ## content (게임 콘텐츠)
 **content** 필드를 반드시 넣어줘. 아래 게임 스펙 중 **무작위로 1개** 골라, 관계·상황·톤에 맞는 내용으로 채워줘. 선택하지 않은 게임은 content 안에 키를 넣지 마.

--- a/src/main/resources/prompts/games/gacha.txt
+++ b/src/main/resources/prompts/games/gacha.txt
@@ -1,0 +1,4 @@
+### gacha (캡슐 뽑기)
+- **play_count**: 숫자 (예: 3). 전체 가챌 기회.
+- **list**: 배열. 항목: item_name, image_url, percent(0~1 소수), percent_open(true/false).
+- 상황에 맞는 경품 1~3개로 구성.

--- a/src/main/resources/prompts/games/quiz.txt
+++ b/src/main/resources/prompts/games/quiz.txt
@@ -1,0 +1,5 @@
+### quiz (퀴즈 이벤트)
+- **success_reward**: required_count, item_name, image_url. (맞춘 개수 기준 충족 시 보상)
+- **fail_reward**: item_name, image_url. (기준 미달 시 참가상)
+- **list**: 배열. 항목: quiz_id(1부터), type("multiple_choice"|"subjective"|"ox"), title, image_url, description, hint, options(배열, 주관식/ox면 []), answer(배열), play_limit(숫자).
+- 관계·상황에 맞는 퀴즈 1~3문항.

--- a/src/main/resources/prompts/games/unboxing.txt
+++ b/src/main/resources/prompts/games/unboxing.txt
@@ -1,0 +1,4 @@
+### unboxing (선물 개봉)
+- **before_open**: image_url, description. (개봉 전 상자·문구)
+- **after_open**: item_name, image_url. (개봉 후 선물)
+- 상황에 맞는 선물 하나로 구성.


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 작업을 했는지 한 줄 요약
    - Curate Service

---

## ✨ 주요 변경 사항
- 변경된 파일 및 폴더 구조
- 구현한 주요 기능 및 변경점
    - Curate 폼 입력 후 전송시 추천 템플릿 생성

---

## ✅ 작업 체크리스트
- [ ] Curate 기본 서비스 개발
- [ ] 이미지 처리 기능 추가

---

## 📂 테스트 방법
- [ ] Swagger를 통한 Post Test


---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: `close #8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능

* **AI 기반 개인화 콘텐츠 큐레이션 생성 기능 추가**
  * 세 가지 큐레이션 엔드포인트 지원: 전체 생성, 이미지 제외 생성, 이미지 추가 생성
  * Azure OpenAI를 활용한 갤러리 이미지 자동 생성
  * 가챠, 퀴즈, 언박싱 등 다양한 게임 콘텐츠 유형 지원
  * 관계, 상황, 톤, 연령대 기반 맞춤형 콘텐츠 자동 생성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->