### PR TITLE
[fix] 알파 채널 포함 PNG 이미지 업로드 실패 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,13 @@ dependencies {
 	// AWS S3 SDK (Lightsail Object Storage S3 호환)
 	implementation platform('software.amazon.awssdk:bom:2.29.52')
 	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:auth'
 
 	// 이미지 압축
 	implementation 'net.coobird:thumbnailator:0.4.20'
+
+	// WebP 이미지 포맷 지원
+	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,6 @@ dependencies {
 	// 이미지 압축
 	implementation 'net.coobird:thumbnailator:0.4.20'
 
-	// WebP 이미지 포맷 지원
-	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gifo/backend/service/storage/StorageService.java
+++ b/src/main/java/com/gifo/backend/service/storage/StorageService.java
@@ -4,6 +4,7 @@ import com.gifo.backend.dto.storage.ImageType;
 import com.gifo.backend.global.ErrorCode;
 import com.gifo.backend.global.exception.storage.StorageException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,13 +16,16 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import javax.imageio.ImageIO;
+
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StorageService {
@@ -54,6 +58,7 @@ public class StorageService {
 
             s3Client.putObject(putRequest, RequestBody.fromBytes(compressed));
         } catch (IOException | S3Exception | SdkClientException e) {
+            log.error("[STORAGE] upload failed: {} - {}", e.getClass().getName(), e.getMessage(), e);
             throw new StorageException(ErrorCode.STORAGE_UPLOAD_FAILED);
         }
 
@@ -61,14 +66,14 @@ public class StorageService {
     }
 
     private byte[] compress(MultipartFile file) throws IOException {
-        try (InputStream in = file.getInputStream();
-             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            BufferedImage original = Thumbnails.of(in)
-                    .size(1920, 1920)
-                    .keepAspectRatio(true)
-                    .asBufferedImage();
+        try {
+            // webp-imageio가 ServiceLoader로 등록되어 WebP 포함 모든 포맷 지원
+            BufferedImage original = ImageIO.read(new ByteArrayInputStream(file.getBytes()));
+            if (original == null) {
+                throw new IOException("지원하지 않는 이미지 포맷입니다.");
+            }
 
-            // JPEG는 알파 채널 미지원 → RGB로 변환
+            // JPEG는 알파 채널 미지원 → 흰 배경 RGB로 변환
             BufferedImage rgb = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_RGB);
             java.awt.Graphics2D g = rgb.createGraphics();
             try {
@@ -77,12 +82,16 @@ public class StorageService {
                 g.dispose();
             }
 
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
             Thumbnails.of(rgb)
-                    .scale(1)
+                    .size(1920, 1920)
+                    .keepAspectRatio(true)
                     .outputFormat("JPEG")
                     .outputQuality(0.8)
                     .toOutputStream(output);
             return output.toByteArray();
+        } catch (Exception e) {
+            throw new IOException("이미지 파일을 읽을 수 없습니다: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/gifo/backend/service/storage/StorageService.java
+++ b/src/main/java/com/gifo/backend/service/storage/StorageService.java
@@ -70,7 +70,12 @@ public class StorageService {
 
             // JPEG는 알파 채널 미지원 → RGB로 변환
             BufferedImage rgb = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_RGB);
-            rgb.createGraphics().drawImage(original, 0, 0, java.awt.Color.WHITE, null);
+            java.awt.Graphics2D g = rgb.createGraphics();
+            try {
+                g.drawImage(original, 0, 0, java.awt.Color.WHITE, null);
+            } finally {
+                g.dispose();
+            }
 
             Thumbnails.of(rgb)
                     .scale(1)

--- a/src/main/java/com/gifo/backend/service/storage/StorageService.java
+++ b/src/main/java/com/gifo/backend/service/storage/StorageService.java
@@ -118,6 +118,20 @@ public class StorageService {
         if (!ALLOWED_CONTENT_TYPES.contains(contentType) || !ALLOWED_EXTENSIONS.contains(extension)) {
             throw new StorageException(ErrorCode.INVALID_FILE_TYPE);
         }
+
+        // 확장자와 무관하게 실제 WebP 파일 거부 (RIFF....WEBP 시그니처)
+        try {
+            byte[] header = file.getBytes();
+            if (header.length >= 12
+                    && header[0] == 'R' && header[1] == 'I' && header[2] == 'F' && header[3] == 'F'
+                    && header[8] == 'W' && header[9] == 'E' && header[10] == 'B' && header[11] == 'P') {
+                throw new StorageException(ErrorCode.INVALID_FILE_TYPE);
+            }
+        } catch (StorageException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new StorageException(ErrorCode.EMPTY_FILE);
+        }
     }
 
     private String extractExtension(String filename) {

--- a/src/main/java/com/gifo/backend/service/storage/StorageService.java
+++ b/src/main/java/com/gifo/backend/service/storage/StorageService.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,9 +63,17 @@ public class StorageService {
     private byte[] compress(MultipartFile file) throws IOException {
         try (InputStream in = file.getInputStream();
              ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            Thumbnails.of(in)
+            BufferedImage original = Thumbnails.of(in)
                     .size(1920, 1920)
                     .keepAspectRatio(true)
+                    .asBufferedImage();
+
+            // JPEG는 알파 채널 미지원 → RGB로 변환
+            BufferedImage rgb = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_RGB);
+            rgb.createGraphics().drawImage(original, 0, 0, java.awt.Color.WHITE, null);
+
+            Thumbnails.of(rgb)
+                    .scale(1)
                     .outputFormat("JPEG")
                     .outputQuality(0.8)
                     .toOutputStream(output);

--- a/src/main/java/com/gifo/backend/service/storage/StorageService.java
+++ b/src/main/java/com/gifo/backend/service/storage/StorageService.java
@@ -22,6 +22,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -66,33 +67,30 @@ public class StorageService {
     }
 
     private byte[] compress(MultipartFile file) throws IOException {
-        try {
-            // webp-imageio가 ServiceLoader로 등록되어 WebP 포함 모든 포맷 지원
-            BufferedImage original = ImageIO.read(new ByteArrayInputStream(file.getBytes()));
-            if (original == null) {
-                throw new IOException("지원하지 않는 이미지 포맷입니다.");
-            }
-
-            // JPEG는 알파 채널 미지원 → 흰 배경 RGB로 변환
-            BufferedImage rgb = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_RGB);
-            java.awt.Graphics2D g = rgb.createGraphics();
-            try {
-                g.drawImage(original, 0, 0, java.awt.Color.WHITE, null);
-            } finally {
-                g.dispose();
-            }
-
-            ByteArrayOutputStream output = new ByteArrayOutputStream();
-            Thumbnails.of(rgb)
-                    .size(1920, 1920)
-                    .keepAspectRatio(true)
-                    .outputFormat("JPEG")
-                    .outputQuality(0.8)
-                    .toOutputStream(output);
-            return output.toByteArray();
-        } catch (Exception e) {
-            throw new IOException("이미지 파일을 읽을 수 없습니다: " + e.getMessage(), e);
+        byte[] bytes = file.getBytes();
+        // JPEG/PNG 지원 (WebP는 validate()에서 거부됨)
+        BufferedImage original = ImageIO.read(new ByteArrayInputStream(bytes));
+        if (original == null) {
+            throw new IOException("지원하지 않는 이미지 포맷입니다.");
         }
+
+        // JPEG는 알파 채널 미지원 → 흰 배경 RGB로 변환
+        BufferedImage rgb = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D g = rgb.createGraphics();
+        try {
+            g.drawImage(original, 0, 0, java.awt.Color.WHITE, null);
+        } finally {
+            g.dispose();
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Thumbnails.of(rgb)
+                .size(1920, 1920)
+                .keepAspectRatio(true)
+                .outputFormat("JPEG")
+                .outputQuality(0.8)
+                .toOutputStream(output);
+        return output.toByteArray();
     }
 
     public void delete(String imageUrl) {
@@ -119,10 +117,11 @@ public class StorageService {
             throw new StorageException(ErrorCode.INVALID_FILE_TYPE);
         }
 
-        // 확장자와 무관하게 실제 WebP 파일 거부 (RIFF....WEBP 시그니처)
-        try {
-            byte[] header = file.getBytes();
-            if (header.length >= 12
+        // 확장자와 무관하게 실제 WebP 파일 거부 (RIFF....WEBP 시그니처) — 12바이트만 읽어 메모리 절약
+        try (InputStream is = file.getInputStream()) {
+            byte[] header = new byte[12];
+            int read = is.read(header);
+            if (read == 12
                     && header[0] == 'R' && header[1] == 'I' && header[2] == 'F' && header[3] == 'F'
                     && header[8] == 'W' && header[9] == 'E' && header[10] == 'B' && header[11] == 'P') {
                 throw new StorageException(ErrorCode.INVALID_FILE_TYPE);


### PR DESCRIPTION
## 📌 작업 개요
- PNG 확장자로 업로드된 WebP 파일로 인해 `STORAGE_UPLOAD_FAILED` 발생하는 버그 수정
- WebP 파일을 확장자와 무관하게 매직 바이트로 감지하여 `INVALID_FILE_TYPE`으로 명확히 거부

---

## ✨ 주요 변경 사항
- `StorageService.validate()`: WebP 매직 바이트(`RIFF....WEBP`) 감지 로직 추가
  - 확장자가 `.png`여도 실제 WebP 파일이면 `INVALID_FILE_TYPE` 반환
- `StorageService.compress()`: `Imaging.getBufferedImage()` → `ImageIO.read()` 교체
  - 알파 채널 포함 이미지는 흰 배경 RGB로 변환 후 JPEG 인코딩
- `build.gradle`: 네이티브 라이브러리 의존 `webp-imageio` 제거, `commons-imaging` 제거
## 스크린샷
<img width="1489" height="576" alt="image" src="https://github.com/user-attachments/assets/a58ae48a-3b97-42c5-bc24-21caf499f006" />
- 이미지처럼 지원하지 않는 포맷 예외 추가

## 💬 기타 참고 사항
- `webp-imageio`는 JNI 네이티브 라이브러리가 Docker 환경에서 초기화 실패(`NoClassDefFoundError`)하여 제거
- WebP 파일은 클라이언트에서 PNG/JPEG로 변환 후 업로드 필요
- 일반 PNG/JPEG는 기존과 동일하게 동작하며 투명 영역은 흰색 배경으로 처리