### PR TITLE
[feat] 캡슐 뽑기 이력에 당첨 시각(drawnAt) 필드 추가

### DIFF
--- a/docs/api-spec-open.md
+++ b/docs/api-spec-open.md
@@ -195,14 +195,16 @@ GET /events/{eventUrl}
         "giftName": "양말 세트",
         "giftImageUrl": "https://example.com/socks.jpg",
         "description": "따뜻한 양말 세트!",
-        "selected": false
+        "selected": false,
+        "drawnAt": "2026-04-09T22:30:00"
       },
       {
         "capsuleId": 7,
         "giftName": "에어팟 프로",
         "giftImageUrl": "https://example.com/airpods.jpg",
         "description": "축하해요!",
-        "selected": false
+        "selected": false,
+        "drawnAt": "2026-04-09T22:31:15"
       }
     ]
   },
@@ -227,6 +229,7 @@ GET /events/{eventUrl}
 | `drawHistory[].giftImageUrl` | String | 뽑힌 선물 이미지 URL |
 | `drawHistory[].description` | String | 선물 설명 |
 | `drawHistory[].selected` | boolean | 최종 선택 여부 |
+| `drawHistory[].drawnAt` | String (ISO 8601) | 당첨 시각 (예: `"2026-04-09T22:30:00"`) |
 
 ---
 

--- a/src/main/java/com/gifo/backend/dto/event/EventResponse.java
+++ b/src/main/java/com/gifo/backend/dto/event/EventResponse.java
@@ -1,5 +1,6 @@
 package com.gifo.backend.dto.event;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -62,7 +63,8 @@ public class EventResponse {
             String giftName,
             String giftImageUrl,
             String description,
-            boolean selected
+            boolean selected,
+            LocalDateTime drawnAt
     ) {}
 
     /**

--- a/src/main/java/com/gifo/backend/service/event/BirthdayEventService.java
+++ b/src/main/java/com/gifo/backend/service/event/BirthdayEventService.java
@@ -174,7 +174,8 @@ public class BirthdayEventService {
                         d.getCapsule().getGift().getGiftName(),
                         d.getCapsule().getGift().getGiftImageUrl(),
                         d.getCapsule().getGift().getDescription(),
-                        d.getSelected()))
+                        d.getSelected(),
+                        d.getCreatedAt()))
                 .toList();
 
         return new EventResponse.GachaContent(

--- a/src/test/java/com/gifo/backend/integration/CapsuleApiTest.java
+++ b/src/test/java/com/gifo/backend/integration/CapsuleApiTest.java
@@ -136,7 +136,8 @@ class CapsuleApiTest {
                 .andExpect(jsonPath("$.data.content.gacha.drawHistory.length()").value(3))
                 .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].capsuleId").isNumber())
                 .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].giftName").isString())
-                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].selected").value(false));
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].selected").value(false))
+                .andExpect(jsonPath("$.data.content.gacha.drawHistory[0].drawnAt").isString());
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 개요
- 캡슐 뽑기 이력(drawHistory)에 당첨 시각(`drawnAt`) 필드 추가

---

## ✨ 주요 변경 사항
- `EventResponse.DrawHistoryItem`에 `drawnAt(LocalDateTime)` 필드 추가
- `BirthdayEventService.buildGachaContent()`에서 `CapsuleDraw.createdAt` 매핑
- DB 스키마 변경 없음 (BaseEntity의 `created_at` 컬럼 이미 존재)

---

## 🖼️ 기능 살펴 보기
- [x] API 문서(요청, 응답)와 일치하는지 확인

**변경 후 drawHistory 응답 예시:**
```json
{
  "capsuleId": 3,
  "giftName": "양말 세트",
  "giftImageUrl": "https://example.com/socks.jpg",
  "description": "따뜻한 양말 세트!",
  "selected": false,
  "drawnAt": "2026-04-09T22:30:00"
}
```

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성 — CapsuleApiTest에 drawnAt 필드 존재 검증 추가
- [x] `./gradlew test` 전체 통과 확인

---

## 💬 기타 참고 사항
- 프론트에서 기프티콘 프레임 이미지 변환 시 당첨 시간 표기에 활용
- BaseEntity의 `@PrePersist`로 뽑기 시점에 자동 저장되므로 별도 로직 불필요

---

## 📎 관련 이슈 / 문서
- close #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 뽑기 이력에 드로우 시간(ISO 8601 형식) 정보 추가

* **Documentation**
  * API 명세서에 드로우 시간 필드 추가 및 문서화

* **Tests**
  * 드로우 시간 필드 검증 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->