### PR TITLE
[Feat] 캡슐 뽑기 API 응답에 당첨 시각(drawnAt) 필드 추가

### DIFF
--- a/docs/api-spec-open.md
+++ b/docs/api-spec-open.md
@@ -381,7 +381,8 @@ POST /events/{eventUrl}/capsules/draw
     "capsuleId": 3,
     "giftName": "에어팟 프로",
     "giftImageUrl": "https://example.com/airpods.jpg",
-    "description": "축하해요! 에어팟 프로를 뽑았습니다!"
+    "description": "축하해요! 에어팟 프로를 뽑았습니다!",
+    "drawnAt": "2026-04-10T14:30:00"
   }
 }
 ```
@@ -392,6 +393,7 @@ POST /events/{eventUrl}/capsules/draw
 | `giftName` | String | 뽑힌 선물 이름 |
 | `giftImageUrl` | String | 뽑힌 선물 이미지 URL |
 | `description` | String | 선물 설명 |
+| `drawnAt` | String (ISO 8601) | 당첨 시각 (기프티콘 프레임 이미지 생성 시 표기용, 예: `"2026-04-10T14:30:00"`) |
 
 ### 에러 케이스
 

--- a/src/main/java/com/gifo/backend/dto/capsule/CapsuleResponse.java
+++ b/src/main/java/com/gifo/backend/dto/capsule/CapsuleResponse.java
@@ -1,5 +1,7 @@
 package com.gifo.backend.dto.capsule;
 
+import java.time.LocalDateTime;
+
 /**
  * 캡슐 도메인 응답 DTO
  */
@@ -8,12 +10,14 @@ public class CapsuleResponse {
     /**
      * POST /events/{eventUrl}/capsules/draw 응답
      * 뽑기 결과로 획득한 선물 정보 (단건)
+     * drawnAt: 당첨 시각 (기프티콘 프레임 이미지 생성 시 표기용)
      */
     public record Draw(
             Long capsuleId,
             String giftName,
             String giftImageUrl,
-            String description
+            String description,
+            LocalDateTime drawnAt
     ) {}
 
     /**

--- a/src/main/java/com/gifo/backend/service/capsule/CapsuleService.java
+++ b/src/main/java/com/gifo/backend/service/capsule/CapsuleService.java
@@ -72,8 +72,8 @@ public class CapsuleService {
         // 가중치 기반 랜덤 추첨
         Capsule drawn = weightedRandom(remaining);
 
-        // 뽑기 이력 저장 (selected=false)
-        capsuleDrawRepository.save(CapsuleDraw.builder()
+        // 뽑기 이력 저장 (selected=false) — createdAt이 당첨 시각
+        CapsuleDraw savedDraw = capsuleDrawRepository.save(CapsuleDraw.builder()
                 .capsuleEvent(capsuleEvent)
                 .capsule(drawn)
                 .build());
@@ -83,7 +83,8 @@ public class CapsuleService {
                 drawn.getCapsuleId(),
                 gift.getGiftName(),
                 gift.getGiftImageUrl(),
-                gift.getDescription());
+                gift.getDescription(),
+                savedDraw.getCreatedAt());
     }
 
     /**

--- a/src/test/java/com/gifo/backend/integration/CapsuleApiTest.java
+++ b/src/test/java/com/gifo/backend/integration/CapsuleApiTest.java
@@ -117,7 +117,8 @@ class CapsuleApiTest {
                 .andExpect(jsonPath("$.data.capsuleId").isNumber())
                 .andExpect(jsonPath("$.data.giftName").isString())
                 .andExpect(jsonPath("$.data.giftImageUrl").isString())
-                .andExpect(jsonPath("$.data.description").isString());
+                .andExpect(jsonPath("$.data.description").isString())
+                .andExpect(jsonPath("$.data.drawnAt").isString()); // 당첨 시각
     }
 
     @Test

--- a/src/test/java/com/gifo/backend/integration/CapsuleFullFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/CapsuleFullFlowTest.java
@@ -97,6 +97,7 @@ class CapsuleFullFlowTest {
             String result = mockMvc.perform(post("/events/{eventUrl}/capsules/draw", eventUrl))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.capsuleId").isNumber())
+                    .andExpect(jsonPath("$.data.drawnAt").isString()) // 당첨 시각
                     .andReturn().getResponse().getContentAsString();
             drawnCapsuleIds[i] = objectMapper.readTree(result).path("data").path("capsuleId").asLong();
         }
@@ -124,6 +125,7 @@ class CapsuleFullFlowTest {
             String result = mockMvc.perform(post("/events/{eventUrl}/capsules/draw", eventUrl))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.capsuleId").isNumber())
+                    .andExpect(jsonPath("$.data.drawnAt").isString()) // 당첨 시각
                     .andReturn().getResponse().getContentAsString();
             drawnCapsuleIds[i] = objectMapper.readTree(result).path("data").path("capsuleId").asLong();
         }

--- a/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
+++ b/src/test/java/com/gifo/backend/integration/ResumeFlowTest.java
@@ -112,6 +112,7 @@ class ResumeFlowTest {
         String drawResult = mockMvc.perform(post("/events/RESUME09/capsules/draw"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.capsuleId").isNumber())
+                .andExpect(jsonPath("$.data.drawnAt").isString()) // 당첨 시각
                 .andReturn().getResponse().getContentAsString();
         Long capsuleId = objectMapper.readTree(drawResult).path("data").path("capsuleId").asLong();
 


### PR DESCRIPTION
## 📌 작업 개요
- `POST /events/{eventUrl}/capsules/draw` 뽑기 응답에 당첨 시각(`drawnAt`) 필드 추가

---

## ✨ 주요 변경 사항
- `CapsuleResponse.Draw` 레코드에 `LocalDateTime drawnAt` 필드 추가
- `CapsuleService.drawCapsule()` 에서 저장된 `CapsuleDraw.getCreatedAt()` 을 반환값에 포함
- `docs/api-spec-open.md` — draw API 응답 명세에 `drawnAt` 필드 및 예시 추가
- 통합 테스트(`CapsuleApiTest`, `CapsuleFullFlowTest`, `ResumeFlowTest`)에 `drawnAt` 검증 추가

---

## 🖼️ 기능 살펴 보기
- [ ] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (통합 테스트)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
  - `CapsuleApiTest` - draw 응답에 `drawnAt` isString 검증
  - `CapsuleFullFlowTest` - 전체 플로우 draw 응답마다 `drawnAt` 검증
  - `ResumeFlowTest` - 선택 후 추가 뽑기 시 `drawnAt` 검증

---

## 💬 기타 참고 사항
- 기존 `drawHistory` 조회 시에는 이미 `drawnAt`이 포함되어 있었으나, 뽑기 직후 응답에는 없어서 프론트에서 로컬 상태 구성 시 시각 정보를 알 수 없었음
- `drawnAt`은 `CapsuleDraw.createdAt` (`@PrePersist` 자동 세팅)을 그대로 반환

---

## 📎 관련 이슈 / 문서
- close #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캡슐 추첨 API 응답에 `drawnAt` 필드 추가됨. 해당 필드는 선물을 추첨한 시간을 ISO 8601 형식으로 제공하며, 선물 프레임 이미지 생성 시 활용할 수 있습니다.

* **문서**
  * API 사양 문서가 새 응답 필드로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->