### PR TITLE
[fix] JVM 타임존 Asia/Seoul 고정

### DIFF
--- a/src/main/java/com/gifo/backend/BackendApplication.java
+++ b/src/main/java/com/gifo/backend/BackendApplication.java
@@ -1,6 +1,5 @@
 package com.gifo.backend;
 
-import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -9,8 +8,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 public class BackendApplication {
 
-	@PostConstruct
-	void setTimeZone() {
+	static {
 		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 

--- a/src/main/java/com/gifo/backend/BackendApplication.java
+++ b/src/main/java/com/gifo/backend/BackendApplication.java
@@ -1,10 +1,18 @@
 package com.gifo.backend;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class BackendApplication {
+
+	@PostConstruct
+	void setTimeZone() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);


### PR DESCRIPTION
## 📌 작업 개요
- 배포 서버(UTC)에서 LocalDateTime.now()가 한국 시간이 아닌 문제 수정

---

## ✨ 주요 변경 사항
- `BackendApplication`에 `@PostConstruct`로 `TimeZone.setDefault("Asia/Seoul")` 설정
- 모든 `LocalDateTime.now()` 호출에 일괄 적용 (BaseEntity, Service 등)

---

## 🖼️ 기능 살펴 보기
- [x] API 문서와 일치하는지 확인

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료
- [x] 기능별 예외 케이스 고려
- [x] 변수명, 클래스명, 메서드명 의미있게 작성

---

## 📂 테스트 방법
- [x] `./gradlew test` 전체 통과 확인

---

## 💬 기타 참고 사항
- drawnAt 등 시간 관련 필드가 한국 시간(KST)으로 정확하게 저장됨

---

## 📎 관련 이슈 / 문서
- 관련 PR: #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 애플리케이션 시작 시 JVM 기본 시간대가 "Asia/Seoul"로 자동 설정되도록 변경되어, 서버 전반의 날짜/시간 처리가 일관되게 한국 표준시로 적용됩니다. 이로 인해 로그, 예약, 일정 등 시간 관련 동작의 표준화와 예측 가능성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->